### PR TITLE
feat: remove publish configs from package.json files

### DIFF
--- a/projects/valtimo/account/package.json
+++ b/projects/valtimo/account/package.json
@@ -2,9 +2,6 @@
   "name": "@valtimo/account",
   "license": "EUPL-1.2",
   "version": "4.15.2",
-  "publishConfig": {
-    "registry": "http://repo.ritense.com/repository/npm-ritense-private/"
-  },
   "peerDependencies": {
     "moment": "2.24.0",
     "@angular/common": "^10.0.11",

--- a/projects/valtimo/auth0/package.json
+++ b/projects/valtimo/auth0/package.json
@@ -6,9 +6,6 @@
     "@angular/common": "^10.0.11",
     "@angular/core": "^10.0.11"
   },
-  "publishConfig": {
-    "registry": "http://repo.ritense.com/repository/npm-ritense-private/"
-  },
   "dependencies": {
     "auth0-js": "^9.13.4",
     "@auth0/angular-jwt": "^5.0.1",

--- a/projects/valtimo/authority/package.json
+++ b/projects/valtimo/authority/package.json
@@ -2,9 +2,6 @@
   "name": "@valtimo/authority",
   "license": "EUPL-1.2",
   "version": "4.15.2",
-  "publishConfig": {
-    "registry": "http://repo.ritense.com/repository/npm-ritense-private/"
-  },
   "peerDependencies": {
     "@angular/common": "^10.0.11",
     "@angular/core": "^10.0.11"

--- a/projects/valtimo/choice-field/package.json
+++ b/projects/valtimo/choice-field/package.json
@@ -2,9 +2,6 @@
   "name": "@valtimo/choice-field",
   "license": "EUPL-1.2",
   "version": "4.15.2",
-  "publishConfig": {
-    "registry": "http://repo.ritense.com/repository/npm-ritense-private/"
-  },
   "peerDependencies": {
     "@angular/common": "^10.0.11",
     "@angular/core": "^10.0.11"

--- a/projects/valtimo/choicefield/package.json
+++ b/projects/valtimo/choicefield/package.json
@@ -2,9 +2,6 @@
   "name": "@valtimo/choicefield",
   "license": "EUPL-1.2",
   "version": "4.15.2",
-  "publishConfig": {
-    "registry": "http://repo.ritense.com/repository/npm-ritense-private/"
-  },
   "peerDependencies": {
     "@angular/common": "^10.0.11",
     "@angular/core": "^10.0.11"

--- a/projects/valtimo/components/package.json
+++ b/projects/valtimo/components/package.json
@@ -7,9 +7,6 @@
     "@angular/core": "^10.0.11",
     "@angular/elements": "^10.0.11"
   },
-  "publishConfig": {
-    "registry": "http://repo.ritense.com/repository/npm-ritense-private/"
-  },
   "dependencies": {
     "@foxythemes/bootstrap-datetime-picker-bs4": "^2.3.4",
     "bpmn-js": "^6.4.2",

--- a/projects/valtimo/context/package.json
+++ b/projects/valtimo/context/package.json
@@ -2,9 +2,6 @@
   "name": "@valtimo/context",
   "license": "EUPL-1.2",
   "version": "4.15.2",
-  "publishConfig": {
-    "registry": "http://repo.ritense.com/repository/npm-ritense-private/"
-  },
   "peerDependencies": {
     "@angular/common": "^10.0.11",
     "@angular/core": "^10.0.11"

--- a/projects/valtimo/dashboard/package.json
+++ b/projects/valtimo/dashboard/package.json
@@ -6,9 +6,6 @@
     "@angular/common": "^10.0.11",
     "@angular/core": "^10.0.11"
   },
-  "publishConfig": {
-    "registry": "http://repo.ritense.com/repository/npm-ritense-private/"
-  },
   "dependencies": {
     "moment": "2.24.0",
     "d3": "^5.9.2",

--- a/projects/valtimo/document/package.json
+++ b/projects/valtimo/document/package.json
@@ -2,9 +2,6 @@
   "name": "@valtimo/document",
   "license": "EUPL-1.2",
   "version": "4.15.2",
-  "publishConfig": {
-    "registry": "http://repo.ritense.com/repository/npm-ritense-private/"
-  },
   "peerDependencies": {
     "@angular/common": "^10.0.11",
     "@angular/core": "^10.0.11"

--- a/projects/valtimo/dossier/package.json
+++ b/projects/valtimo/dossier/package.json
@@ -2,9 +2,6 @@
   "name": "@valtimo/dossier",
   "license": "EUPL-1.2",
   "version": "4.15.2",
-  "publishConfig": {
-    "registry": "http://repo.ritense.com/repository/npm-ritense-private/"
-  },
   "peerDependencies": {
     "@angular/common": "^10.0.11",
     "@angular/core": "^10.0.11"

--- a/projects/valtimo/keycloak/package.json
+++ b/projects/valtimo/keycloak/package.json
@@ -6,9 +6,6 @@
     "@angular/common": "^10.0.11",
     "@angular/core": "^10.0.11"
   },
-  "publishConfig": {
-    "registry": "http://repo.ritense.com/repository/npm-ritense-private/"
-  },
   "dependencies": {
     "keycloak-angular": "^8.0.1",
     "keycloak-js": "^10.0.2",

--- a/projects/valtimo/layout/package.json
+++ b/projects/valtimo/layout/package.json
@@ -6,9 +6,6 @@
     "@angular/common": "^10.0.11",
     "@angular/core": "^10.0.11"
   },
-  "publishConfig": {
-    "registry": "http://repo.ritense.com/repository/npm-ritense-private/"
-  },
   "dependencies": {
     "@foxythemes/material-design-iconic-font": "^2.2.1",
     "@foxythemes/gritter": "^1.7.4",

--- a/projects/valtimo/management/package.json
+++ b/projects/valtimo/management/package.json
@@ -7,9 +7,6 @@
     "@angular/core": "^10.0.11",
     "@angular/elements": "^10.0.11"
   },
-  "publishConfig": {
-    "registry": "http://repo.ritense.com/repository/npm-ritense-private/"
-  },
   "dependencies": {
     "jquery": "3.4.1",
     "moment": "2.24.0",

--- a/projects/valtimo/process/package.json
+++ b/projects/valtimo/process/package.json
@@ -2,9 +2,6 @@
   "name": "@valtimo/process",
   "license": "EUPL-1.2",
   "version": "4.15.2",
-  "publishConfig": {
-    "registry": "http://repo.ritense.com/repository/npm-ritense-private/"
-  },
   "peerDependencies": {
     "@angular/common": "^10.0.11",
     "@angular/core": "^10.0.11"

--- a/projects/valtimo/security/package.json
+++ b/projects/valtimo/security/package.json
@@ -6,9 +6,6 @@
     "@angular/common": "^10.0.11",
     "@angular/core": "^10.0.11"
   },
-  "publishConfig": {
-    "registry": "http://repo.ritense.com/repository/npm-ritense-private/"
-  },
   "dependencies": {
     "ngx-toastr": "^13.0.0",
     "tslib": "^2.0.0"

--- a/projects/valtimo/task/package.json
+++ b/projects/valtimo/task/package.json
@@ -2,9 +2,6 @@
   "name": "@valtimo/task",
   "license": "EUPL-1.2",
   "version": "4.15.2",
-  "publishConfig": {
-    "registry": "http://repo.ritense.com/repository/npm-ritense-private/"
-  },
   "peerDependencies": {
     "@angular/common": "^10.0.11",
     "@angular/core": "^10.0.11"

--- a/projects/valtimo/user-management/package.json
+++ b/projects/valtimo/user-management/package.json
@@ -2,9 +2,6 @@
   "name": "@valtimo/user-management",
   "license": "EUPL-1.2",
   "version": "4.15.2",
-  "publishConfig": {
-    "registry": "http://repo.ritense.com/repository/npm-ritense-private/"
-  },
   "peerDependencies": {
     "@angular/common": "^10.0.11",
     "@angular/core": "^10.0.11"

--- a/projects/valtimo/view-configurator/package.json
+++ b/projects/valtimo/view-configurator/package.json
@@ -2,9 +2,6 @@
   "name": "@valtimo/view-configurator",
   "license": "EUPL-1.2",
   "version": "4.15.2",
-  "publishConfig": {
-    "registry": "http://repo.ritense.com/repository/npm-ritense-private/"
-  },
   "peerDependencies": {
     "@angular/common": "^10.0.11",
     "@angular/core": "^10.0.11"


### PR DESCRIPTION
Removed redundant publish configs from each library's package.json file. These configurations are no longer needed, since the libraries are now published publicly to NPM. 