### PR TITLE
Add extra toggle class to display the menu component which is currently hidden on mobile and smaller screens

### DIFF
--- a/projects/valtimo/layout/src/beagle/src/js/app.js
+++ b/projects/valtimo/layout/src/beagle/src/js/app.js
@@ -418,8 +418,10 @@ var App = (function () {
     /*Toggle sidebar on small devices*/
       lsToggle.on('click',function( e ){
         var spacer = $(this).next('.left-sidebar-spacer'), toggleBtn = $(this);
-
+        var toggleSpacerMenu = $(".left-sidebar-spacer");
         toggleBtn.toggleClass('open');
+        toggleSpacerMenu.toggleClass('open');
+
         spacer.slideToggle(config.leftSidebarToggleSpeed, function(){
           $(this).removeAttr('style').toggleClass('open');
         });


### PR DESCRIPTION
In the current version it's not possible to see the menu on a mobile devices (or with a smaller resolution), because it is missing a specific "open" class that should be applied when the menu open is triggered. It's seems that the issue is in the beagle file, but I was not able to find anything in the official documentation. Not sure when this functionality broke but it has been working in older versions.