### PR TITLE
Removed property used to block refresh of formio form

### DIFF
--- a/projects/valtimo/components/src/lib/form-io/form-io.component.html
+++ b/projects/valtimo/components/src/lib/form-io/form-io.component.html
@@ -24,7 +24,7 @@
   </div>
   <formio [submission]="submission"
           [form]="formDefinition"
-          [refresh]="useFormRefresh && refreshForm"
+          [refresh]="refreshForm"
           [options]="options"
           [language]="language"
           (submit)="onSubmit($event)"

--- a/projects/valtimo/components/src/lib/form-io/form-io.component.ts
+++ b/projects/valtimo/components/src/lib/form-io/form-io.component.ts
@@ -36,7 +36,6 @@ export class FormioComponent implements OnInit, OnChanges, OnDestroy {
   @Input() options: ValtimoFormioOptions;
   @Input() submission?: object | {} = {};
   @Input() formRefresh$!: Subject<FormioRefreshValue>;
-  @Input() useFormRefresh = false;
   @Output() submit: EventEmitter<any> = new EventEmitter();
   @Output() change: EventEmitter<any> = new EventEmitter();
   refreshForm: EventEmitter<FormioRefreshValue> = new EventEmitter();

--- a/projects/valtimo/connector-management/src/lib/components/edit-product-aanvragen-connector/edit-product-aanvragen-connector.component.html
+++ b/projects/valtimo/connector-management/src/lib/components/edit-product-aanvragen-connector/edit-product-aanvragen-connector.component.html
@@ -22,7 +22,6 @@
   <valtimo-form-io
     [form]="definition"
     [formRefresh$]="formRefresh$"
-    [useFormRefresh]="true"
     [options]="options"
     (change)="onChange($event)"
     (submit)="onSubmit($event)"


### PR DESCRIPTION
Property was used as a quick fix for upload components, but is causing other issues with locale based number formatting among others. Since upload component has been refactored this property is not needed anymore. 