### PR TITLE
feat: popup to save note on contact moments tab

### DIFF
--- a/projects/valtimo/config/src/lib/translation/assets/core/de.json
+++ b/projects/valtimo/config/src/lib/translation/assets/core/de.json
@@ -36,6 +36,9 @@
       "body": "Nachricht",
       "sendButtonText": "Senden",
       "sendSuccess": "Ihre Nachricht wurde erfolgreich gesendet."
+    },
+    "contactMoments": {
+      "makeNoteButton": "Notizen machen"
     }
   },
   "document": {

--- a/projects/valtimo/config/src/lib/translation/assets/core/de.json
+++ b/projects/valtimo/config/src/lib/translation/assets/core/de.json
@@ -38,7 +38,11 @@
       "sendSuccess": "Ihre Nachricht wurde erfolgreich gesendet."
     },
     "contactMoments": {
-      "makeNoteButton": "Notizen machen"
+      "makeNoteButton": "Notizen machen",
+      "popupTitle": "Eine Notiz machen",
+      "noteText": "Notiz",
+      "saveButtonText": "Notiz speichern",
+      "saveSuccess": "Ihre Notiz wurde erfolgreich gespeichert."
     }
   },
   "document": {

--- a/projects/valtimo/config/src/lib/translation/assets/core/en.json
+++ b/projects/valtimo/config/src/lib/translation/assets/core/en.json
@@ -10,7 +10,7 @@
     "DocumentRelatedFileAddedEvent": "Related file added",
     "DocumentRelatedFileRemovedEvent": "Related file removed"
   },
-  "dossier": {
+  "dossierdossier": {
     "title": {
       "single": "Case",
       "plural": "Cases"
@@ -36,6 +36,9 @@
       "body": "Body",
       "sendButtonText": "Send",
       "sendSuccess": "Your message has been sent successfully."
+    },
+    "contactMoments": {
+      "makeNoteButton": "Make note"
     }
   },
   "document": {

--- a/projects/valtimo/config/src/lib/translation/assets/core/en.json
+++ b/projects/valtimo/config/src/lib/translation/assets/core/en.json
@@ -10,7 +10,7 @@
     "DocumentRelatedFileAddedEvent": "Related file added",
     "DocumentRelatedFileRemovedEvent": "Related file removed"
   },
-  "dossierdossier": {
+  "dossier": {
     "title": {
       "single": "Case",
       "plural": "Cases"

--- a/projects/valtimo/config/src/lib/translation/assets/core/en.json
+++ b/projects/valtimo/config/src/lib/translation/assets/core/en.json
@@ -38,7 +38,11 @@
       "sendSuccess": "Your message has been sent successfully."
     },
     "contactMoments": {
-      "makeNoteButton": "Make note"
+      "makeNoteButton": "Make note",
+      "popupTitle": "Make a note",
+      "noteText": "Note",
+      "saveButtonText": "Save note",
+      "saveSuccess": "Your note has been saved successfully."
     }
   },
   "document": {

--- a/projects/valtimo/config/src/lib/translation/assets/core/nl.json
+++ b/projects/valtimo/config/src/lib/translation/assets/core/nl.json
@@ -38,7 +38,11 @@
       "sendSuccess": "Uw bericht is succesvol verzonden."
     },
     "contactMoments": {
-      "makeNoteButton": "Aantekening maken"
+      "makeNoteButton": "Aantekening maken",
+      "popupTitle": "Een aantekening maken",
+      "noteText": "Aantekening",
+      "saveButtonText": "Aantekening opslaan",
+      "saveSuccess": "Uw aantekening is succesvol opgeslagen."
     }
   },
   "document": {

--- a/projects/valtimo/config/src/lib/translation/assets/core/nl.json
+++ b/projects/valtimo/config/src/lib/translation/assets/core/nl.json
@@ -36,6 +36,9 @@
       "body": "Inhoud",
       "sendButtonText": "Versturen",
       "sendSuccess": "Uw bericht is succesvol verzonden."
+    },
+    "contactMoments": {
+      "makeNoteButton": "Aantekening maken"
     }
   },
   "document": {

--- a/projects/valtimo/contact-moment/src/lib/contact-moment.service.ts
+++ b/projects/valtimo/contact-moment/src/lib/contact-moment.service.ts
@@ -18,7 +18,7 @@ import {Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {Observable} from 'rxjs';
 import {ConfigService} from '@valtimo/config';
-import {Contactmoment} from './contact-moment.model';
+import {Contactmoment, CreateContactMomentRequest} from '@valtimo/contract';
 
 @Injectable({
   providedIn: 'root'
@@ -34,4 +34,7 @@ export class ContactMomentService {
     return this.http.get<Contactmoment[]>(`${this.valtimoEndpointUri}contactmoment`);
   }
 
+  saveContactMoment(contactMomentRequest: CreateContactMomentRequest): Observable<Contactmoment> {
+    return this.http.post(`${this.valtimoEndpointUri}contactmoment`, contactMomentRequest);
+  }
 }

--- a/projects/valtimo/contact-moment/src/public_api.ts
+++ b/projects/valtimo/contact-moment/src/public_api.ts
@@ -17,6 +17,5 @@
 /*
  * Public API Surface of contact-moment
  */
-export * from './lib/contact-moment.model';
 export * from './lib/contact-moment.module';
 export * from './lib/contact-moment.service';

--- a/projects/valtimo/contract/src/lib/contact-moment.model.ts
+++ b/projects/valtimo/contract/src/lib/contact-moment.model.ts
@@ -24,3 +24,8 @@ export interface Contactmoment {
 export interface MedewerkerIdentificatie {
   achternaam?: string;
 }
+
+export interface CreateContactMomentRequest {
+  kanaal: string;
+  tekst: string;
+}

--- a/projects/valtimo/contract/src/public-api.ts
+++ b/projects/valtimo/contract/src/public-api.ts
@@ -59,3 +59,4 @@ export * from './lib/upload.model';
 export * from './lib/connector.model';
 export * from './lib/pagination.model';
 export * from './lib/object-sync';
+export * from './lib/contact-moment.model'

--- a/projects/valtimo/contract/src/public-api.ts
+++ b/projects/valtimo/contract/src/public-api.ts
@@ -59,4 +59,4 @@ export * from './lib/upload.model';
 export * from './lib/connector.model';
 export * from './lib/pagination.model';
 export * from './lib/object-sync';
-export * from './lib/contact-moment.model'
+export * from './lib/contact-moment.model';

--- a/projects/valtimo/dossier/src/lib/dossier-detail/tab/contact-moments/contact-moments.component.html
+++ b/projects/valtimo/dossier/src/lib/dossier-detail/tab/contact-moments/contact-moments.component.html
@@ -15,14 +15,70 @@
   -->
 
 <div class="contact-moments-container">
+  <ng-container *ngTemplateOutlet="buttons"></ng-container>
+  <ng-container *ngTemplateOutlet="moments"></ng-container>
+</div>
+
+<valtimo-modal
+    #contactMomentsNoteModal
+    [title]="'dossier.contactMoments.popupTitle' | translate"
+    [showFooter]="true"
+    [elementId]="'contact-moments-modal'"
+>
+  <div class="mt-2" body>
+    <ng-container *ngTemplateOutlet="body"></ng-container>
+  </div>
+  <div footer>
+    <ng-container *ngTemplateOutlet="footer"></ng-container>
+  </div>
+</valtimo-modal>
+
+<ng-template #body>
+  <form>
+    <div class="form-group row">
+      <label class="col-12 col-sm-3 col-form-label text-sm-right" for="body">
+        {{ 'dossier.contactMoments.noteText' | translate }}
+      </label>
+      <div class="col-12 col-sm-8 col-lg-6">
+        <textarea
+          [disabled]="disabled$ | async"
+          class="form-control"
+          id="body"
+          name="body"
+          [ngModel]="text$ | async"
+          (ngModelChange)="textChange($event)"
+        ></textarea>
+      </div>
+    </div>
+  </form>
+</ng-template>
+
+<ng-template #footer>
+  <button
+    *ngIf="(disabled$ | async) === false; else loading"
+    class="btn btn-primary"
+    [disabled]="(valid$ | async) === false || (disabled$ | async)"
+    (click)="saveNote()"
+  >
+    {{ "dossier.contactMoments.saveButtonText" | translate }}
+  </button>
+</ng-template>
+
+<ng-template #loading>
+  <valtimo-spinner [noMarginTop]="true"></valtimo-spinner>
+</ng-template>
+
+<ng-template #buttons>
   <div class="btn-group mt-m3px mb-3 button-container">
-    <button class="btn btn-primary btn-space">
+    <button class="btn btn-primary btn-space" (click)="buttonClick()">
       <i class="icon mdi mdi-calendar-note"></i>
       &nbsp;{{ "dossier.contactMoments.makeNoteButton" | translate }}
     </button>
   </div>
-  <div *ngIf="contactMoments">
+</ng-template>
+
+<ng-template #moments>
+  <div *ngIf="contactMoments$ | async as contactMoments; else loading">
     <valtimo-timeline [items]="contactMoments"></valtimo-timeline>
   </div>
-</div>
-
+</ng-template>

--- a/projects/valtimo/dossier/src/lib/dossier-detail/tab/contact-moments/contact-moments.component.html
+++ b/projects/valtimo/dossier/src/lib/dossier-detail/tab/contact-moments/contact-moments.component.html
@@ -14,7 +14,15 @@
   ~ limitations under the License.
   -->
 
-<div *ngIf="contactMoments">
-  <valtimo-timeline [items]="contactMoments"></valtimo-timeline>
+<div class="contact-moments-container">
+  <div class="btn-group mt-m3px mb-3 button-container">
+    <button class="btn btn-primary btn-space">
+      <i class="icon mdi mdi-calendar-note"></i>
+      &nbsp;{{ "dossier.contactMoments.makeNoteButton" | translate }}
+    </button>
+  </div>
+  <div *ngIf="contactMoments">
+    <valtimo-timeline [items]="contactMoments"></valtimo-timeline>
+  </div>
 </div>
 

--- a/projects/valtimo/dossier/src/lib/dossier-detail/tab/contact-moments/contact-moments.component.scss
+++ b/projects/valtimo/dossier/src/lib/dossier-detail/tab/contact-moments/contact-moments.component.scss
@@ -14,3 +14,12 @@
  * limitations under the License.
  */
 
+.contact-moments-container {
+  display: flex;
+  flex-direction: column;
+}
+
+.button-container {
+  display: inline;
+  align-self: flex-end;
+}

--- a/projects/valtimo/dossier/src/lib/dossier-detail/tab/contact-moments/contact-moments.component.ts
+++ b/projects/valtimo/dossier/src/lib/dossier-detail/tab/contact-moments/contact-moments.component.ts
@@ -14,10 +14,15 @@
  * limitations under the License.
  */
 
-import {Component, OnInit} from '@angular/core';
-import {Contactmoment, ContactMomentService} from '@valtimo/contact-moment';
+import {Component, ViewChild} from '@angular/core';
+import {ContactMomentService} from '@valtimo/contact-moment';
 import * as moment_ from 'moment';
 import {TimelineItem, TimelineItemImpl} from '@valtimo/contract';
+import {BehaviorSubject, combineLatest, Observable, Subject} from 'rxjs';
+import {ModalComponent} from '@valtimo/components';
+import {map, switchMap, take} from 'rxjs/operators';
+import {AlertService} from '@valtimo/components';
+import {TranslateService} from '@ngx-translate/core';
 
 const moment = moment_;
 moment.locale(localStorage.getItem('langKey') || '');
@@ -27,33 +32,80 @@ moment.locale(localStorage.getItem('langKey') || '');
   templateUrl: './contact-moments.component.html',
   styleUrls: ['./contact-moments.component.scss']
 })
-export class DossierDetailTabContactMomentsComponent implements OnInit {
-  public contactMoments: Array<TimelineItem> = [];
+export class DossierDetailTabContactMomentsComponent {
+  @ViewChild('contactMomentsNoteModal') modal: ModalComponent;
 
-  constructor(
-      private readonly contactMomentService: ContactMomentService,
-  ) {
-  }
-
-  ngOnInit() {
-    this.loadContactMoments();
-  }
-
-  private loadContactMoments(): void {
-    this.contactMomentService.getContactMoments().subscribe(contactMoments => this.handleContactMomentsResult(contactMoments));
-  }
-
-  private handleContactMomentsResult(contactMoments: Array<Contactmoment>): void {
-    this.contactMoments = contactMoments.map(contactMoment => {
+  readonly refetchContactMoments$ = new BehaviorSubject('');
+  readonly contactMoments$: Observable<Array<TimelineItem>> = this.refetchContactMoments$.pipe(
+    switchMap(() => this.contactMomentService.getContactMoments()),
+    map((contactMoments) => contactMoments.map(contactMoment => {
       const registratieDatum = moment(contactMoment.registratiedatum);
       return new TimelineItemImpl(
-          registratieDatum.format('DD MMM YYYY'),
-          registratieDatum.format('HH:mm'),
-          contactMoment.medewerkerIdentificatie.achternaam,
-          contactMoment.kanaal,
-          contactMoment.tekst,
-          null
+        registratieDatum.format('DD MMM YYYY'),
+        registratieDatum.format('HH:mm'),
+        contactMoment.medewerkerIdentificatie.achternaam,
+        contactMoment.kanaal,
+        contactMoment.tekst,
+        null
+      );
+    }))
+  );
+
+  readonly text$ = new BehaviorSubject<string>('');
+  readonly channel$ = new BehaviorSubject<string>('MAIL');
+  readonly requestData$: Observable<Array<string>> = combineLatest([this.text$, this.channel$]);
+  readonly valid$: Observable<boolean> = this.requestData$.pipe(
+    map(([text, channel]) => !!(text && channel))
+  );
+  readonly disabled$ = new BehaviorSubject<boolean>(false);
+
+  constructor(
+    private readonly contactMomentService: ContactMomentService,
+    private readonly alertService: AlertService,
+    private readonly translateService: TranslateService
+  ) { }
+
+  textChange(text: string): void {
+    this.text$.next(text);
+  }
+
+  buttonClick(): void {
+    this.modal.show();
+  }
+
+  saveNote(): void {
+    this.disable();
+
+    this.requestData$.pipe(take(1)).subscribe(([text, channel]) => {
+      this.contactMomentService.saveContactMoment({kanaal: channel, tekst: text}).subscribe(
+        () => {
+          this.alertService.success(this.translateService.instant('dossier.contactMoments.saveSuccess'));
+          this.enable();
+          this.clear();
+          this.modal.hide();
+          this.refetchContactMoments();
+        },
+        () => {
+          this.enable();
+        }
       );
     });
   }
+
+  private disable(): void {
+    this.disabled$.next(true);
+  }
+
+  private enable(): void {
+    this.disabled$.next(false);
+  }
+
+  private clear(): void {
+    this.text$.next('');
+  }
+
+  private refetchContactMoments(): void {
+    this.refetchContactMoments$.next('');
+  }
+
 }


### PR DESCRIPTION
Adds a button on the contact moments tab on a dossier detail page, which opens a popup which allows the user to manually save a note of a contact moment. Closes https://ritense.tpondemand.com/entity/32838-aantekening-van-klantcontact-vastleggen-buiten-proces