### PR TITLE
fix: task modal subtitle timestamp

### DIFF
--- a/projects/valtimo/task/src/lib/task-detail-modal/task-detail-modal.component.ts
+++ b/projects/valtimo/task/src/lib/task-detail-modal/task-detail-modal.component.ts
@@ -69,7 +69,7 @@ export class TaskDetailModalComponent {
     this.task = task;
     this.page = {
       title: task.name,
-      subtitle: `Created ${moment(task.created).fromNow()}`,
+      subtitle: `Created ${task.created}`,
     };
     this.formLinkService
       .getPreFilledFormDefinitionByFormLinkId(


### PR DESCRIPTION
* modified task modal subtitle to show task creation timestamp correctly instead of "Invalid Date"