### PR TITLE
bugfix 33714 - Klanten menu fix

### DIFF
--- a/projects/valtimo/config/src/lib/services/menu-include.service.ts
+++ b/projects/valtimo/config/src/lib/services/menu-include.service.ts
@@ -50,7 +50,7 @@ export class MenuIncludeService {
 
   private getHaalCentraalConnectorInstances(): Observable<Page<ConnectorInstance>> {
     return this.http.get<Page<ConnectorInstance>>(
-      `${this.valtimoConfig.valtimoApi.endpointUri}connector/instance?typeName=HaalCentraal`
+      `${this.valtimoConfig.valtimoApi.endpointUri}connector/instance?typeName=HaalCentraalBrp`
     );
   }
 }


### PR DESCRIPTION
The klanten menu checked against the old HaalCentraal connector. It will now check against the new HaalCentraalBrp connector