### PR TITLE
fix: downgrade @ng-bootstrap/ng-bootstrap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@foxythemes/morris.js": "^0.5.1",
         "@foxythemes/sparkline": "^2.1.3",
         "@mdi/font": "^6.5.95",
-        "@ng-bootstrap/ng-bootstrap": "^12.0.0",
+        "@ng-bootstrap/ng-bootstrap": "^11.0.0",
         "@ng-select/ng-select": "^8.1.1",
         "@ngx-translate/core": "^14.0.0",
         "@ngx-translate/http-loader": "^7.0.0",
@@ -176,7 +176,7 @@
     },
     "dist/valtimo/account": {
       "name": "@valtimo/account",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -190,7 +190,7 @@
     },
     "dist/valtimo/analyse": {
       "name": "@valtimo/analyse",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -203,7 +203,7 @@
     },
     "dist/valtimo/auth0": {
       "name": "@valtimo/auth0",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -218,7 +218,7 @@
     },
     "dist/valtimo/authority": {
       "name": "@valtimo/authority",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -231,7 +231,7 @@
     },
     "dist/valtimo/bootstrap": {
       "name": "@valtimo/bootstrap",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -244,7 +244,7 @@
     },
     "dist/valtimo/choice-field": {
       "name": "@valtimo/choice-field",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -257,7 +257,7 @@
     },
     "dist/valtimo/choicefield": {
       "name": "@valtimo/choicefield",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -270,7 +270,7 @@
     },
     "dist/valtimo/components": {
       "name": "@valtimo/components",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -295,9 +295,26 @@
         "@angular/elements": "^13.2.3"
       }
     },
+    "dist/valtimo/components/node_modules/@ng-bootstrap/ng-bootstrap": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@ng-bootstrap/ng-bootstrap/-/ng-bootstrap-12.1.2.tgz",
+      "integrity": "sha512-p27c+mYVdHiJMYrj5hwClVJxLdiZxafAqlbw1sdJh2xJ1rGOe+H/kCf5YDRbhlHqRN+34Gr0RQqIUeD1I2V8hg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^13.0.0",
+        "@angular/core": "^13.0.0",
+        "@angular/forms": "^13.0.0",
+        "@angular/localize": "^13.0.0",
+        "@popperjs/core": "^2.10.2",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
     "dist/valtimo/config": {
       "name": "@valtimo/config",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -310,7 +327,7 @@
     },
     "dist/valtimo/connector-management": {
       "name": "@valtimo/connector-management",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -324,7 +341,7 @@
     },
     "dist/valtimo/contact-moment": {
       "name": "@valtimo/contact-moment",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -337,7 +354,7 @@
     },
     "dist/valtimo/context": {
       "name": "@valtimo/context",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -350,7 +367,7 @@
     },
     "dist/valtimo/customer": {
       "name": "@valtimo/customer",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -363,7 +380,7 @@
     },
     "dist/valtimo/dashboard": {
       "name": "@valtimo/dashboard",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -381,7 +398,7 @@
     },
     "dist/valtimo/decision": {
       "name": "@valtimo/decision",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -395,7 +412,7 @@
     },
     "dist/valtimo/document": {
       "name": "@valtimo/document",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -408,7 +425,7 @@
     },
     "dist/valtimo/dossier": {
       "name": "@valtimo/dossier",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -426,7 +443,7 @@
     },
     "dist/valtimo/dossier-management": {
       "name": "@valtimo/dossier-management",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -439,7 +456,7 @@
     },
     "dist/valtimo/form-link": {
       "name": "@valtimo/form-link",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -452,7 +469,7 @@
     },
     "dist/valtimo/form-management": {
       "name": "@valtimo/form-management",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -465,7 +482,7 @@
     },
     "dist/valtimo/keycloak": {
       "name": "@valtimo/keycloak",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -480,7 +497,7 @@
     },
     "dist/valtimo/layout": {
       "name": "@valtimo/layout",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -540,7 +557,7 @@
     },
     "dist/valtimo/management": {
       "name": "@valtimo/management",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -575,7 +592,7 @@
     },
     "dist/valtimo/migration": {
       "name": "@valtimo/migration",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -588,7 +605,7 @@
     },
     "dist/valtimo/milestone": {
       "name": "@valtimo/milestone",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -602,7 +619,7 @@
     },
     "dist/valtimo/open-zaak": {
       "name": "@valtimo/open-zaak",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -615,7 +632,7 @@
     },
     "dist/valtimo/plugin": {
       "name": "@valtimo/plugin",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -629,7 +646,7 @@
     },
     "dist/valtimo/plugin-management": {
       "name": "@valtimo/plugin-management",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -643,7 +660,7 @@
     },
     "dist/valtimo/process": {
       "name": "@valtimo/process",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -661,7 +678,7 @@
     },
     "dist/valtimo/process-management": {
       "name": "@valtimo/process-management",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -676,7 +693,7 @@
     },
     "dist/valtimo/resource": {
       "name": "@valtimo/resource",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -689,7 +706,7 @@
     },
     "dist/valtimo/security": {
       "name": "@valtimo/security",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -703,7 +720,7 @@
     },
     "dist/valtimo/swagger": {
       "name": "@valtimo/swagger",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -717,7 +734,7 @@
     },
     "dist/valtimo/task": {
       "name": "@valtimo/task",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -732,7 +749,7 @@
     },
     "dist/valtimo/user-interface": {
       "name": "@valtimo/user-interface",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -760,7 +777,7 @@
     },
     "dist/valtimo/user-management": {
       "name": "@valtimo/user-management",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -772,9 +789,26 @@
         "@angular/core": "^13.2.3"
       }
     },
+    "dist/valtimo/user-management/node_modules/@ng-bootstrap/ng-bootstrap": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@ng-bootstrap/ng-bootstrap/-/ng-bootstrap-12.1.2.tgz",
+      "integrity": "sha512-p27c+mYVdHiJMYrj5hwClVJxLdiZxafAqlbw1sdJh2xJ1rGOe+H/kCf5YDRbhlHqRN+34Gr0RQqIUeD1I2V8hg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^13.0.0",
+        "@angular/core": "^13.0.0",
+        "@angular/forms": "^13.0.0",
+        "@angular/localize": "^13.0.0",
+        "@popperjs/core": "^2.10.2",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
     "dist/valtimo/view-configurator": {
       "name": "@valtimo/view-configurator",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -3517,8 +3551,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ng-bootstrap/ng-bootstrap": {
-      "version": "12.1.2",
-      "license": "MIT",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@ng-bootstrap/ng-bootstrap/-/ng-bootstrap-11.0.1.tgz",
+      "integrity": "sha512-xpXpW2x2S9ZQhEu5kCmEAFf8WvkVD+rcKb1NLQiLuiZgAQR7GXVexXy5Y+RIvTjAQmPEVyxaSgYiJA6sWNJLNw==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -3527,7 +3562,6 @@
         "@angular/core": "^13.0.0",
         "@angular/forms": "^13.0.0",
         "@angular/localize": "^13.0.0",
-        "@popperjs/core": "^2.10.2",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -20616,7 +20650,9 @@
       "version": "6.9.96"
     },
     "@ng-bootstrap/ng-bootstrap": {
-      "version": "12.1.2",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@ng-bootstrap/ng-bootstrap/-/ng-bootstrap-11.0.1.tgz",
+      "integrity": "sha512-xpXpW2x2S9ZQhEu5kCmEAFf8WvkVD+rcKb1NLQiLuiZgAQR7GXVexXy5Y+RIvTjAQmPEVyxaSgYiJA6sWNJLNw==",
       "requires": {
         "tslib": "^2.3.0"
       }
@@ -21448,6 +21484,17 @@
         "ngx-spinner": "^13.1.1",
         "ngx-toastr": "^14.3.0",
         "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "@ng-bootstrap/ng-bootstrap": {
+          "version": "12.1.2",
+          "resolved": "https://registry.npmjs.org/@ng-bootstrap/ng-bootstrap/-/ng-bootstrap-12.1.2.tgz",
+          "integrity": "sha512-p27c+mYVdHiJMYrj5hwClVJxLdiZxafAqlbw1sdJh2xJ1rGOe+H/kCf5YDRbhlHqRN+34Gr0RQqIUeD1I2V8hg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        }
       }
     },
     "@valtimo/config": {
@@ -21717,6 +21764,17 @@
       "requires": {
         "@ng-bootstrap/ng-bootstrap": "^12.0.0",
         "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "@ng-bootstrap/ng-bootstrap": {
+          "version": "12.1.2",
+          "resolved": "https://registry.npmjs.org/@ng-bootstrap/ng-bootstrap/-/ng-bootstrap-12.1.2.tgz",
+          "integrity": "sha512-p27c+mYVdHiJMYrj5hwClVJxLdiZxafAqlbw1sdJh2xJ1rGOe+H/kCf5YDRbhlHqRN+34Gr0RQqIUeD1I2V8hg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        }
       }
     },
     "@valtimo/view-configurator": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -276,7 +276,7 @@
       "dependencies": {
         "@formio/angular": "^5.2.2",
         "@foxythemes/bootstrap-datetime-picker-bs4": "^2.3.4",
-        "@ng-bootstrap/ng-bootstrap": "^12.0.0",
+        "@ng-bootstrap/ng-bootstrap": "^11.0.0",
         "@ngx-translate/core": "^14.0.0",
         "@ngx-translate/http-loader": "7.0.0",
         "bpmn-js": "^6.4.2",
@@ -561,7 +561,7 @@
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
-        "@ng-bootstrap/ng-bootstrap": "^7.0.0",
+        "@ng-bootstrap/ng-bootstrap": "^11.0.0",
         "@ngx-translate/core": "^14.0.0",
         "@ngx-translate/http-loader": "7.0.0",
         "jquery": "3.6.0",
@@ -572,22 +572,6 @@
         "@angular/common": "^13.2.3",
         "@angular/core": "^13.2.3",
         "@angular/elements": "^13.2.3"
-      }
-    },
-    "dist/valtimo/management/node_modules/@ng-bootstrap/ng-bootstrap": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@ng-bootstrap/ng-bootstrap/-/ng-bootstrap-7.0.0.tgz",
-      "integrity": "sha512-SxUaptGWJmCxM0d2Zy1mx7K7p/YBwGZ69NmmBQVY4BE6p5av0hWrVmv9rzzfBz0rhxU7RPZLor2Jpaoq8Xyl4w==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "^10.0.0",
-        "@angular/core": "^10.0.0",
-        "@angular/forms": "^10.0.0",
-        "@angular/localize": "^10.0.0",
-        "rxjs": "^6.5.5"
       }
     },
     "dist/valtimo/migration": {
@@ -781,7 +765,7 @@
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
-        "@ng-bootstrap/ng-bootstrap": "^12.0.0",
+        "@ng-bootstrap/ng-bootstrap": "^11.0.0",
         "tslib": "^2.0.0"
       },
       "peerDependencies": {
@@ -21472,7 +21456,7 @@
       "requires": {
         "@formio/angular": "^5.2.2",
         "@foxythemes/bootstrap-datetime-picker-bs4": "^2.3.4",
-        "@ng-bootstrap/ng-bootstrap": "^12.0.0",
+        "@ng-bootstrap/ng-bootstrap": "^11.0.0",
         "@ngx-translate/core": "^14.0.0",
         "@ngx-translate/http-loader": "7.0.0",
         "bpmn-js": "^6.4.2",
@@ -21487,8 +21471,7 @@
       },
       "dependencies": {
         "@ng-bootstrap/ng-bootstrap": {
-          "version": "12.1.2",
-          "resolved": "https://registry.npmjs.org/@ng-bootstrap/ng-bootstrap/-/ng-bootstrap-12.1.2.tgz",
+          "version": "https://registry.npmjs.org/@ng-bootstrap/ng-bootstrap/-/ng-bootstrap-12.1.2.tgz",
           "integrity": "sha512-p27c+mYVdHiJMYrj5hwClVJxLdiZxafAqlbw1sdJh2xJ1rGOe+H/kCf5YDRbhlHqRN+34Gr0RQqIUeD1I2V8hg==",
           "dev": true,
           "requires": {
@@ -21644,23 +21627,12 @@
     "@valtimo/management": {
       "version": "file:dist/valtimo/management",
       "requires": {
-        "@ng-bootstrap/ng-bootstrap": "^7.0.0",
+        "@ng-bootstrap/ng-bootstrap": "^11.0.0",
         "@ngx-translate/core": "^14.0.0",
         "@ngx-translate/http-loader": "7.0.0",
         "jquery": "3.6.0",
         "moment": "^2.29.4",
         "tslib": "^2.0.0"
-      },
-      "dependencies": {
-        "@ng-bootstrap/ng-bootstrap": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@ng-bootstrap/ng-bootstrap/-/ng-bootstrap-7.0.0.tgz",
-          "integrity": "sha512-SxUaptGWJmCxM0d2Zy1mx7K7p/YBwGZ69NmmBQVY4BE6p5av0hWrVmv9rzzfBz0rhxU7RPZLor2Jpaoq8Xyl4w==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.0.0"
-          }
-        }
       }
     },
     "@valtimo/migration": {
@@ -21762,13 +21734,12 @@
     "@valtimo/user-management": {
       "version": "file:dist/valtimo/user-management",
       "requires": {
-        "@ng-bootstrap/ng-bootstrap": "^12.0.0",
+        "@ng-bootstrap/ng-bootstrap": "^11.0.0",
         "tslib": "^2.0.0"
       },
       "dependencies": {
         "@ng-bootstrap/ng-bootstrap": {
-          "version": "12.1.2",
-          "resolved": "https://registry.npmjs.org/@ng-bootstrap/ng-bootstrap/-/ng-bootstrap-12.1.2.tgz",
+          "version": "https://registry.npmjs.org/@ng-bootstrap/ng-bootstrap/-/ng-bootstrap-12.1.2.tgz",
           "integrity": "sha512-p27c+mYVdHiJMYrj5hwClVJxLdiZxafAqlbw1sdJh2xJ1rGOe+H/kCf5YDRbhlHqRN+34Gr0RQqIUeD1I2V8hg==",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
     "@foxythemes/morris.js": "^0.5.1",
     "@foxythemes/sparkline": "^2.1.3",
     "@mdi/font": "^6.5.95",
-    "@ng-bootstrap/ng-bootstrap": "^12.0.0",
+    "@ng-bootstrap/ng-bootstrap": "^11.0.0",
     "@ng-select/ng-select": "^8.1.1",
     "@ngx-translate/core": "^14.0.0",
     "@ngx-translate/http-loader": "^7.0.0",

--- a/projects/valtimo/components/package.json
+++ b/projects/valtimo/components/package.json
@@ -16,7 +16,7 @@
     "heatmap.js-fixed": "^2.0.2",
     "@ngx-translate/core": "^14.0.0",
     "@ngx-translate/http-loader": "7.0.0",
-    "@ng-bootstrap/ng-bootstrap": "^12.0.0",
+    "@ng-bootstrap/ng-bootstrap": "^11.0.0",
     "ngx-toastr": "^14.3.0",
     "@formio/angular": "^5.2.2",
     "ngx-spinner": "^13.1.1",

--- a/projects/valtimo/management/package.json
+++ b/projects/valtimo/management/package.json
@@ -12,7 +12,7 @@
     "moment": "^2.29.4",
     "@ngx-translate/core": "^14.0.0",
     "@ngx-translate/http-loader": "7.0.0",
-    "@ng-bootstrap/ng-bootstrap": "^7.0.0",
+    "@ng-bootstrap/ng-bootstrap": "^11.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/projects/valtimo/user-management/package.json
+++ b/projects/valtimo/user-management/package.json
@@ -7,7 +7,7 @@
     "@angular/core": "^13.2.3"
   },
   "dependencies": {
-    "@ng-bootstrap/ng-bootstrap": "^12.0.0",
+    "@ng-bootstrap/ng-bootstrap": "^11.0.0",
     "tslib": "^2.0.0"
   }
 }


### PR DESCRIPTION
@ng-bootstrap/ng-bootstrap version 12 was not compatible with bootstrap version 4 used by Valtimo: https://www.npmjs.com/package/@ng-bootstrap/ng-bootstrap. Closes https://ritense.tpondemand.com/entity/36385-fe-bootstrap-version-is-incompatible-with