### PR TITLE
fix: fix title component

### DIFF
--- a/projects/valtimo/user-interface/src/lib/components/title/title.component.html
+++ b/projects/valtimo/user-interface/src/lib/components/title/title.component.html
@@ -15,8 +15,12 @@
   -->
 
 <h1 *ngIf="isH1" class="v-title--h1" [ngClass]="{'v-title--no-margin': !margin}">
-  <ng-content></ng-content>
+  <ng-container *ngTemplateOutlet="content"></ng-container>
 </h1>
 <h2 *ngIf="isH2" class="v-title--h2" [ngClass]="{'v-title--no-margin': !margin}">
-  <ng-content></ng-content>
+  <ng-container *ngTemplateOutlet="content"></ng-container>
 </h2>
+
+<ng-template #content>
+  <ng-content></ng-content>
+</ng-template>


### PR DESCRIPTION
Having ng-content twice, only the second one was rendering, meaning that H1 elements did not show any contents. Thanks to this tip, this has been resolved: https://github.com/angular/angular/issues/22972#issuecomment-407358396