### PR TITLE
fix: change the type of default direction to string

### DIFF
--- a/projects/valtimo/config/src/lib/models/config.ts
+++ b/projects/valtimo/config/src/lib/models/config.ts
@@ -30,7 +30,7 @@ export interface DefinitionColumn {
   translationKey: string;
   sortable?: boolean;
   viewType?: string;
-  default?: boolean | Direction;
+  default?: boolean | string;
 }
 
 export interface CustomDossierHeaderItem {


### PR DESCRIPTION
change the type of default direction to string

US: https://ritense.tpondemand.com/entity/36161-fe-configurable-sorting-direction-case-list