### PR TITLE
feat: fix case list pagination with observables

### DIFF
--- a/projects/valtimo/components/src/lib/components/list/list.component.ts
+++ b/projects/valtimo/components/src/lib/components/list/list.component.ts
@@ -49,6 +49,7 @@ export class ListComponent implements OnChanges, OnInit, AfterViewInit {
   @Input() actions: any[] = [];
   @Input() paginationIdentifier?: string;
   @Input() initialSortState: SortState;
+
   @Output() rowClicked: EventEmitter<any> = new EventEmitter();
   @Output() paginationClicked: EventEmitter<any> = new EventEmitter();
   @Output() paginationSet: EventEmitter<any> = new EventEmitter();
@@ -82,7 +83,7 @@ export class ListComponent implements OnChanges, OnInit, AfterViewInit {
       this.logger.debug(
         'Pagination does NOT exist in local storage for this list. Will use default. Change it to create an entry.'
       );
-      this.paginationSet.emit();
+      this.paginationSet.emit(10);
     }
   }
 

--- a/projects/valtimo/components/src/lib/components/list/list.component.ts
+++ b/projects/valtimo/components/src/lib/components/list/list.component.ts
@@ -111,6 +111,10 @@ export class ListComponent implements OnChanges, OnInit, AfterViewInit {
     if (changes.items && changes.items.currentValue) {
       this.transformListItemsMatchFields();
     }
+
+    if (changes?.initialSortState?.currentValue) {
+      this.sort$.next(changes?.initialSortState?.currentValue);
+    }
   }
 
   ngAfterViewInit() {

--- a/projects/valtimo/components/src/lib/components/list/list.component.ts
+++ b/projects/valtimo/components/src/lib/components/list/list.component.ts
@@ -82,8 +82,8 @@ export class ListComponent implements OnChanges, OnInit, AfterViewInit {
       this.logger.debug(
         'Pagination does NOT exist in local storage for this list. Will use default. Change it to create an entry.'
       );
+      this.paginationSet.emit();
     }
-    this.paginationSet.emit();
   }
 
   setPaginationSize(numberOfEntries: string) {

--- a/projects/valtimo/components/src/lib/components/list/list.component.ts
+++ b/projects/valtimo/components/src/lib/components/list/list.component.ts
@@ -71,7 +71,7 @@ export class ListComponent implements OnChanges, OnInit, AfterViewInit {
     this.viewListAs = localStorage.getItem('viewListAs') || 'table';
   }
 
-  loadPaginationSize() {
+  loadPaginationSize(): void {
     const entries = localStorage.getItem(
       `${this.paginationIdentifier}${ListComponent.PAGINATION_SIZE}`
     );

--- a/projects/valtimo/components/src/lib/models/index.ts
+++ b/projects/valtimo/components/src/lib/models/index.ts
@@ -20,3 +20,4 @@ export * from './pagination.model';
 export * from './searchable-dropdown.model';
 export * from './timeline.model';
 export * from './version.model';
+export * from './list.model';

--- a/projects/valtimo/components/src/lib/models/list.model.ts
+++ b/projects/valtimo/components/src/lib/models/list.model.ts
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-import {SortState} from '@valtimo/document';
-
-interface Pagination {
-  collectionSize: number;
-  page: number;
-  size: number;
-  maxPaginationItemSize: number;
-  sort?: SortState;
+interface ListField {
+  key: string;
+  label: string;
+  sortable: boolean;
+  viewType: string;
 }
 
-export {Pagination};
+export {ListField};

--- a/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.html
+++ b/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.html
@@ -19,15 +19,15 @@
 <div class="main-content pt-0">
   <div class="container-fluid">
     <div class="col-12 px-0 mb-5">
-      <div>
+      <div *ngIf="associatedProcessDefinitions$ | async as associatedProcessDefinitions">
         <div class="text-right mt-m3px mb-3">
           <button
             type="button"
             class="btn btn-space btn-primary mr-0"
             (click)="startDossier()"
-            [ngbTooltip]="processDocumentDefinitions.length === 0 ? 'No action' : null"
+            [ngbTooltip]="associatedProcessDefinitions.length === 0 ? 'No action' : null"
             placement="bottom"
-            [disabled]="processDocumentDefinitions.length === 0"
+            [disabled]="associatedProcessDefinitions.length === 0"
           >
             <i class="icon mdi mdi-plus mr-1"></i>
             {{ 'Start Dossier' | translate }}
@@ -56,7 +56,7 @@
                 <div class="table-responsive">
                   <table class="table m-0">
                     <tr
-                      *ngFor="let processDocumentDefinition of processDocumentDefinitions"
+                      *ngFor="let processDocumentDefinition of associatedProcessDefinitions"
                       (click)="selectProcess(processDocumentDefinition)"
                       style="cursor: pointer"
                     >
@@ -75,33 +75,38 @@
         </div>
       </div>
       <valtimo-widget>
-        <valtimo-list
-          [items]="items"
-          [fields]="fields"
-          (rowClicked)="rowClick($event)"
-          [pagination]="pagination"
-          [viewMode]="true"
-          [header]="true"
-          paginationIdentifier="dossierList"
-          (paginationClicked)="paginationClicked($event)"
-          (paginationSet)="paginationSet()"
-          [initialSortState]="initialSortState"
-          (sortChanged)="sortChanged($event)"
-        >
-          <div header>
-            <h3 class="list-header-title">
-              {{ schema?.title }}
-              <sup class="ml-1 badge badge-pill badge-primary">{{
-                documents?.content.length || 0
-              }}</sup>
-            </h3>
-          </div>
-        </valtimo-list>
+        <ng-container *ngTemplateOutlet="list"></ng-container>
       </valtimo-widget>
     </div>
   </div>
   <valtimo-dossier-process-start-modal #processStartModal></valtimo-dossier-process-start-modal>
 </div>
+
+<ng-template #list>
+  <ng-container *ngIf="paginationCopy$ | async as pagination">
+    <valtimo-list
+      *ngIf="documentItems$ | async as documentItems"
+      [items]="documentItems"
+      [fields]="fields$ | async"
+      (rowClicked)="rowClick($event)"
+      [pagination]="pagination"
+      [viewMode]="true"
+      [header]="true"
+      paginationIdentifier="dossierList"
+      (paginationClicked)="pageChange($event)"
+      (paginationSet)="pageSizeChange($event)"
+      [initialSortState]="pagination.sort"
+      (sortChanged)="sortChanged($event)"
+    >
+      <div header>
+        <h3 class="list-header-title">
+          {{ (schema$ | async)?.title }}
+          <sup class="ml-1 badge badge-pill badge-primary">{{ documentItems?.length || 0 }}</sup>
+        </h3>
+      </div>
+    </valtimo-list>
+  </ng-container>
+</ng-template>
 
 <ng-template #sidebar>
   <valtimo-filter-sidebar>

--- a/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.html
+++ b/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.html
@@ -19,15 +19,19 @@
 <div class="main-content pt-0">
   <div class="container-fluid">
     <div class="col-12 px-0 mb-5">
-      <div *ngIf="associatedProcessDefinitions$ | async as associatedProcessDefinitions">
+      <div
+        *ngIf="
+          associatedProcessDocumentDefinitions$ | async as associatedProcessDocumentDefinitions
+        "
+      >
         <div class="text-right mt-m3px mb-3">
           <button
             type="button"
             class="btn btn-space btn-primary mr-0"
             (click)="startDossier()"
-            [ngbTooltip]="associatedProcessDefinitions.length === 0 ? 'No action' : null"
+            [ngbTooltip]="associatedProcessDocumentDefinitions.length === 0 ? 'No action' : null"
             placement="bottom"
-            [disabled]="associatedProcessDefinitions.length === 0"
+            [disabled]="associatedProcessDocumentDefinitions.length === 0"
           >
             <i class="icon mdi mdi-plus mr-1"></i>
             {{ 'Start Dossier' | translate }}
@@ -56,7 +60,7 @@
                 <div class="table-responsive">
                   <table class="table m-0">
                     <tr
-                      *ngFor="let processDocumentDefinition of associatedProcessDefinitions"
+                      *ngFor="let processDocumentDefinition of associatedProcessDocumentDefinitions"
                       (click)="selectProcess(processDocumentDefinition)"
                       style="cursor: pointer"
                     >

--- a/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.html
+++ b/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.html
@@ -88,27 +88,29 @@
 
 <ng-template #list>
   <ng-container *ngIf="paginationCopy$ | async as pagination">
-    <valtimo-list
-      *ngIf="documentItems$ | async as documentItems"
-      [items]="documentItems"
-      [fields]="fields$ | async"
-      (rowClicked)="rowClick($event)"
-      [pagination]="pagination"
-      [viewMode]="true"
-      [header]="true"
-      paginationIdentifier="dossierList"
-      (paginationClicked)="pageChange($event)"
-      (paginationSet)="pageSizeChange($event)"
-      [initialSortState]="pagination.sort"
-      (sortChanged)="sortChanged($event)"
-    >
-      <div header>
-        <h3 class="list-header-title">
-          {{ (schema$ | async)?.title }}
-          <sup class="ml-1 badge badge-pill badge-primary">{{ documentItems?.length || 0 }}</sup>
-        </h3>
-      </div>
-    </valtimo-list>
+    <ng-container *ngIf="fields$ | async as fields">
+      <valtimo-list
+        *ngIf="documentItems$ | async as documentItems"
+        [items]="documentItems"
+        [fields]="fields"
+        (rowClicked)="rowClick($event)"
+        [pagination]="pagination"
+        [viewMode]="true"
+        [header]="true"
+        paginationIdentifier="dossierList"
+        (paginationClicked)="pageChange($event)"
+        (paginationSet)="pageSizeChange($event)"
+        [initialSortState]="pagination.sort"
+        (sortChanged)="sortChanged($event)"
+      >
+        <div header>
+          <h3 class="list-header-title">
+            {{ (schema$ | async)?.title }}
+            <sup class="ml-1 badge badge-pill badge-primary">{{ documentItems?.length || 0 }}</sup>
+          </h3>
+        </div>
+      </valtimo-list>
+    </ng-container>
   </ng-container>
 </ng-template>
 

--- a/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.html
+++ b/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.html
@@ -85,7 +85,7 @@
           paginationIdentifier="dossierList"
           (paginationClicked)="paginationClicked($event)"
           (paginationSet)="paginationSet()"
-          [initialSortState]="getInitialSortState()"
+          [initialSortState]="initialSortState"
           (sortChanged)="sortChanged($event)"
         >
           <div header>

--- a/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.html
+++ b/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.html
@@ -116,9 +116,8 @@
         type="text"
         class="form-control"
         placeholder="{{ 'dossier.forms.globalSearchPlaceHolder' | translate }}"
-        [(ngModel)]="globalSearchFilter"
-        (blur)="doSearch()"
-        (keyup.enter)="doSearch()"
+        [ngModel]="globalSearchFilter$ | async"
+        (ngModelChange)="globalSearchFilterChange($event)"
       />
     </div>
 
@@ -127,9 +126,8 @@
         type="number"
         class="form-control"
         placeholder="{{ 'dossier.forms.referenceNumberPlaceHolder' | translate }}"
-        [(ngModel)]="sequence"
-        (blur)="doSearch()"
-        (keyup.enter)="doSearch()"
+        [ngModel]="sequence$ | async"
+        (ngModelChange)="sequenceChange($event)"
       />
     </div>
   </valtimo-filter-sidebar>

--- a/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.ts
+++ b/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.ts
@@ -110,7 +110,7 @@ export class DossierListComponent implements OnInit, OnDestroy {
 
     this.documentDefinitionName = documentDefinitionName;
     this.initialSortState = this.dossierService.getInitialSortState(columns);
-
+    this.setCachedInitialSortState();
     this.openTranslationSubscription(columns);
   }
 
@@ -271,11 +271,14 @@ export class DossierListComponent implements OnInit, OnDestroy {
     this.doSearch();
   }
 
-  public getInitialSortState(): SortState {
+  private setCachedInitialSortState(): void {
     if (this.hasCachedSearchRequest()) {
       const cachedRequest = JSON.parse(this.getCachedDocumentSearchRequest());
-      return cachedRequest.sort ? cachedRequest.sort : this.initialSortState;
+      const cachedSort = cachedRequest?.sort;
+
+      if (cachedSort) {
+        this.initialSortState = cachedSort;
+      }
     }
-    return this.initialSortState;
   }
 }

--- a/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.ts
+++ b/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.ts
@@ -127,7 +127,7 @@ export class DossierListComponent implements OnInit {
     )
   );
 
-  private readonly DEFAULT_PAGINATION = {
+  private readonly DEFAULT_PAGINATION: Pagination = {
     collectionSize: 0,
     page: 1,
     size: 10,
@@ -287,23 +287,41 @@ export class DossierListComponent implements OnInit {
     combineLatest([this.hasStoredSearchRequest$, this.storedSearchRequestKey$, this.columns$])
       .pipe(take(1))
       .subscribe(([hasStoredSearchRequest, storedSearchRequestKey, columns]) => {
-        const defaultSortState = this.dossierService.getInitialSortState(columns);
-        const defaultPagination: Pagination = {
-          ...this.DEFAULT_PAGINATION,
-          sort: defaultSortState,
-        };
-        const storedSearchRequest =
-          hasStoredSearchRequest && JSON.parse(localStorage.getItem(storedSearchRequestKey));
-        const storedPagination: Pagination | undefined = storedSearchRequest && {
-          ...this.DEFAULT_PAGINATION,
-          sort: storedSearchRequest.sort,
-          page: storedSearchRequest.page + 1,
-          size: storedSearchRequest.size,
-        };
+        const defaultPagination: Pagination = this.getDefaultPagination(columns);
+        const storedPagination: Pagination = this.getStoredPagination(
+          hasStoredSearchRequest,
+          storedSearchRequestKey
+        );
 
         this.logger.log(`Set pagination: ${JSON.stringify(storedPagination || defaultPagination)}`);
         this.pagination$.next(storedPagination || defaultPagination);
       });
+  }
+
+  private getDefaultPagination(columns: Array<DefinitionColumn>): Pagination {
+    const defaultSortState = this.dossierService.getInitialSortState(columns);
+
+    return {
+      ...this.DEFAULT_PAGINATION,
+      sort: defaultSortState,
+    };
+  }
+
+  private getStoredPagination(
+    hasStoredSearchRequest: boolean,
+    storedSearchRequestKey: string
+  ): Pagination | undefined {
+    const storedSearchRequest =
+      hasStoredSearchRequest && JSON.parse(localStorage.getItem(storedSearchRequestKey));
+
+    return (
+      storedSearchRequest && {
+        ...this.DEFAULT_PAGINATION,
+        sort: storedSearchRequest.sort,
+        page: storedSearchRequest.page + 1,
+        size: storedSearchRequest.size,
+      }
+    );
   }
 
   private setCollectionSize(documents: Documents): void {

--- a/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.ts
+++ b/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.ts
@@ -238,6 +238,16 @@ export class DossierListComponent implements OnInit, OnDestroy {
     this.translationSubscription.unsubscribe();
   }
 
+  globalSearchFilterChange(filter: string): void {
+    this.globalSearchFilter$.next(filter);
+    this.pageChange(1);
+  }
+
+  sequenceChange(sequence: string): void {
+    this.sequence$.next(Number(sequence));
+    this.pageChange(1);
+  }
+
   private resetPagination(documentDefinitionName): void {
     this.settingPaginationForDocName$.pipe(take(1)).subscribe(settingPaginationForDocName => {
       if (documentDefinitionName !== settingPaginationForDocName) {

--- a/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.ts
+++ b/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.ts
@@ -66,9 +66,11 @@ export class DossierListComponent implements OnInit {
   private selectedProcessDocumentDefinition: ProcessDocumentDefinition | null = null;
   private modalListenerAdded = false;
 
-  readonly settingPaginationForDocName$ = new BehaviorSubject<string | undefined>(undefined);
+  private readonly settingPaginationForDocName$ = new BehaviorSubject<string | undefined>(
+    undefined
+  );
 
-  readonly documentDefinitionName$: Observable<string> = this.route.params.pipe(
+  private readonly documentDefinitionName$: Observable<string> = this.route.params.pipe(
     map(params => params.documentDefinitionName || ''),
     tap(documentDefinitionName => {
       this.resetPagination(documentDefinitionName);
@@ -87,13 +89,6 @@ export class DossierListComponent implements OnInit {
       )
     );
 
-  readonly processDefinitionListFields$ = new BehaviorSubject<Array<{key: string; label: string}>>([
-    {
-      key: 'processName',
-      label: 'Proces',
-    },
-  ]);
-
   readonly schema$ = this.documentDefinitionName$.pipe(
     switchMap(documentDefinitionName =>
       this.documentService.getDocumentDefinition(documentDefinitionName)
@@ -101,17 +96,20 @@ export class DossierListComponent implements OnInit {
     map(documentDefinition => documentDefinition?.schema)
   );
 
-  readonly storedSearchRequestKey$: Observable<string> = this.documentDefinitionName$.pipe(
+  private readonly storedSearchRequestKey$: Observable<string> = this.documentDefinitionName$.pipe(
     map(documentDefinitionName => `list-search-${documentDefinitionName}`)
   );
 
-  readonly hasStoredSearchRequest$: Observable<boolean> = this.storedSearchRequestKey$.pipe(
+  private readonly hasStoredSearchRequest$: Observable<boolean> = this.storedSearchRequestKey$.pipe(
     map(storedSearchRequestKey => localStorage.getItem(storedSearchRequestKey) !== null)
   );
 
-  readonly columns$: Observable<Array<DefinitionColumn>> = this.documentDefinitionName$.pipe(
-    map(documentDefinitionName => this.dossierService.getDefinitionColumns(documentDefinitionName))
-  );
+  private readonly columns$: Observable<Array<DefinitionColumn>> =
+    this.documentDefinitionName$.pipe(
+      map(documentDefinitionName =>
+        this.dossierService.getDefinitionColumns(documentDefinitionName)
+      )
+    );
 
   readonly fields$: Observable<Array<ListField>> = combineLatest([
     this.columns$,
@@ -143,11 +141,11 @@ export class DossierListComponent implements OnInit {
 
   readonly sequence$ = new BehaviorSubject<number | undefined>(undefined);
 
-  readonly createdBy$ = new BehaviorSubject<string | undefined>(undefined);
-
   readonly globalSearchFilter$ = new BehaviorSubject<string | undefined>(undefined);
 
-  readonly documentSearchRequest$: Observable<DocumentSearchRequest> = combineLatest([
+  private readonly createdBy$ = new BehaviorSubject<string | undefined>(undefined);
+
+  private readonly documentSearchRequest$: Observable<DocumentSearchRequest> = combineLatest([
     this.pagination$,
     this.documentDefinitionName$,
     this.sequence$,
@@ -169,7 +167,7 @@ export class DossierListComponent implements OnInit {
     )
   );
 
-  readonly documentsRequest$: Observable<Documents> = this.documentSearchRequest$.pipe(
+  private readonly documentsRequest$: Observable<Documents> = this.documentSearchRequest$.pipe(
     distinctUntilChanged((prev, curr) => {
       return JSON.stringify(prev) === JSON.stringify(curr);
     }),
@@ -195,9 +193,9 @@ export class DossierListComponent implements OnInit {
   );
 
   constructor(
-    private route: ActivatedRoute,
-    private router: Router,
-    private documentService: DocumentService,
+    private readonly route: ActivatedRoute,
+    private readonly router: Router,
+    private readonly documentService: DocumentService,
     private readonly translateService: TranslateService,
     private readonly dossierService: DossierService,
     private readonly logger: NGXLogger
@@ -232,6 +230,7 @@ export class DossierListComponent implements OnInit {
         const amountOfAvailablePages = Math.ceil(pagination.collectionSize / newPageSize);
         const newPage =
           amountOfAvailablePages < pagination.page ? amountOfAvailablePages : pagination.page;
+
         this.logger.log(`Page size change. New Page: ${newPage} New page size: ${newPageSize}`);
         this.pagination$.next({...pagination, size: newPageSize, page: newPage});
       }
@@ -249,10 +248,6 @@ export class DossierListComponent implements OnInit {
 
   rowClick(document: any) {
     this.documentDefinitionName$.pipe(take(1)).subscribe(documentDefinitionName => {
-      console.log(
-        'url',
-        `/dossiers/${documentDefinitionName}/document/${document.id}/${DefaultTabs.summary}`
-      );
       this.router.navigate([
         `/dossiers/${documentDefinitionName}/document/${document.id}/${DefaultTabs.summary}`,
       ]);

--- a/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.ts
+++ b/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.ts
@@ -175,10 +175,16 @@ export class DossierListComponent implements OnInit, OnDestroy {
 
   public getCachedSearch(): DocumentSearchRequest {
     const json = JSON.parse(this.getCachedDocumentSearchRequest());
+    const page = json.page || 0;
+    const size = json.size || 10;
+
+    this.pagination.page = page + 1;
+    this.pagination.size = size;
+
     return new DocumentSearchRequestImpl(
       json.definitionName,
-      this.pagination.page - 1,
-      this.pagination.size,
+      page,
+      size,
       json.sequence,
       json.createdBy,
       json.globalSearchFilter,

--- a/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.ts
+++ b/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.ts
@@ -440,10 +440,15 @@ export class DossierListComponent implements OnInit, OnDestroy {
   }
 
   public rowClick(document: any) {
-    console.log('row click');
-    this.router.navigate([
-      `/dossiers/${this.documentDefinitionName}/document/${document.id}/${DefaultTabs.summary}`,
-    ]);
+    this.documentDefinitionName$.pipe(take(1)).subscribe(documentDefinitionName => {
+      console.log(
+        'url',
+        `/dossiers/${documentDefinitionName}/document/${document.id}/${DefaultTabs.summary}`
+      );
+      this.router.navigate([
+        `/dossiers/${documentDefinitionName}/document/${document.id}/${DefaultTabs.summary}`,
+      ]);
+    });
   }
 
   public startDossier() {

--- a/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.ts
+++ b/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.ts
@@ -215,7 +215,7 @@ export class DossierListComponent implements OnInit {
     this.pageChange(1);
   }
 
-  pageChange(newPage: number) {
+  pageChange(newPage: number): void {
     this.pagination$.pipe(take(1)).subscribe(pagination => {
       if (pagination && pagination.page !== newPage) {
         this.logger.log(`Page change: ${newPage}`);
@@ -224,7 +224,7 @@ export class DossierListComponent implements OnInit {
     });
   }
 
-  pageSizeChange(newPageSize: number) {
+  pageSizeChange(newPageSize: number): void {
     this.pagination$.pipe(take(1)).subscribe(pagination => {
       if (pagination && pagination.size !== newPageSize) {
         const amountOfAvailablePages = Math.ceil(pagination.collectionSize / newPageSize);
@@ -237,7 +237,7 @@ export class DossierListComponent implements OnInit {
     });
   }
 
-  sortChanged(newSortState: SortState) {
+  sortChanged(newSortState: SortState): void {
     this.pagination$.pipe(take(1)).subscribe(pagination => {
       if (pagination && JSON.stringify(pagination.sort) !== JSON.stringify(newSortState)) {
         this.logger.log(`Sort state change: ${JSON.stringify(newSortState)}`);
@@ -246,7 +246,7 @@ export class DossierListComponent implements OnInit {
     });
   }
 
-  rowClick(document: any) {
+  rowClick(document: any): void {
     this.documentDefinitionName$.pipe(take(1)).subscribe(documentDefinitionName => {
       this.router.navigate([
         `/dossiers/${documentDefinitionName}/document/${document.id}/${DefaultTabs.summary}`,
@@ -254,7 +254,7 @@ export class DossierListComponent implements OnInit {
     });
   }
 
-  startDossier() {
+  startDossier(): void {
     this.associatedProcessDocumentDefinitions$
       .pipe(take(1))
       .subscribe(associatedProcessDocumentDefinitions => {
@@ -265,6 +265,16 @@ export class DossierListComponent implements OnInit {
           this.showStartProcessModal();
         }
       });
+  }
+
+  selectProcess(processDocumentDefinition: ProcessDocumentDefinition): void {
+    const modal = $('#startProcess');
+    if (!this.modalListenerAdded) {
+      modal.on('hidden.bs.modal', this.showStartProcessModal.bind(this));
+      this.modalListenerAdded = true;
+    }
+    this.selectedProcessDocumentDefinition = processDocumentDefinition;
+    modal.modal('hide');
   }
 
   private resetPagination(documentDefinitionName): void {
@@ -327,20 +337,10 @@ export class DossierListComponent implements OnInit {
     });
   }
 
-  private showStartProcessModal() {
+  private showStartProcessModal(): void {
     if (this.selectedProcessDocumentDefinition !== null) {
       this.processStart.openModal(this.selectedProcessDocumentDefinition);
       this.selectedProcessDocumentDefinition = null;
     }
-  }
-
-  public selectProcess(processDocumentDefinition: ProcessDocumentDefinition) {
-    const modal = $('#startProcess');
-    if (!this.modalListenerAdded) {
-      modal.on('hidden.bs.modal', this.showStartProcessModal.bind(this));
-      this.modalListenerAdded = true;
-    }
-    this.selectedProcessDocumentDefinition = processDocumentDefinition;
-    modal.modal('hide');
   }
 }

--- a/projects/valtimo/user-interface/src/lib/components/title/title.component.html
+++ b/projects/valtimo/user-interface/src/lib/components/title/title.component.html
@@ -15,8 +15,12 @@
   -->
 
 <h1 *ngIf="isH1" class="v-title--h1" [ngClass]="{'v-title--no-margin': !margin}">
-  <ng-content></ng-content>
+  <ng-container *ngTemplateOutlet="content"></ng-container>
 </h1>
 <h2 *ngIf="isH2" class="v-title--h2" [ngClass]="{'v-title--no-margin': !margin}">
-  <ng-content></ng-content>
+  <ng-container *ngTemplateOutlet="content"></ng-container>
 </h2>
+
+<ng-template #content>
+  <ng-content></ng-content>
+</ng-template>


### PR DESCRIPTION
Refactor case list component to work with observables, fix issues:
- Go to correct page number on switching case definitions
- Fix pagination indicator showing new page number on switching case definitions  
- Call function to get initial sort state infinitely from component code
- Switch to last available page on choosing a larger page size
- Go to first page on typing in search term or sequence for searching
- On case definition load: get pagination (including sorting) from cache. If this does not exist, get default pagination and sorting (from environment)
- On switching case definitions, the sort state of the previously selected case definition was used. This has now been fixed, and the case definition uses either its cached sort state or default sort state (environment)
- Does not show results sometimes on directly reloading case list page

Closes https://ritense.tpondemand.com/entity/35803-fe-case-list-pagination-is-shared
Fixes comments on: https://ritense.tpondemand.com/entity/36161-fe-configurable-sorting-direction-case-list