### PR TITLE
feat: new design dropdown seems disabled

### DIFF
--- a/projects/valtimo/user-interface/assets/design-tokens.css
+++ b/projects/valtimo/user-interface/assets/design-tokens.css
@@ -192,8 +192,10 @@
   --v-select-selected-background-color: var(--v-color-grey-3);
   --v-select-highlighted-background-color: var(--v-color-grey-4);
   --v-select-disabled-font-color: var(--v-color-grey-2);
+  --v-select-disabled-bg-color: var(--v-color-grey-4);
   --v-select-placeholder-font-color: var(--v-color-grey-2);
   --v-select-font-color: var(--v-color-grey-1);
+  --v-select-darker-font-color: var(--v-color-grey-0);
   --v-select-arrow-color: var(--v-color-grey-2);
   --v-select-arrow-hover-color: var(--v-color-grey-1);
   --v-select-border-radius: var(--v-border-radius-md);

--- a/projects/valtimo/user-interface/assets/design-tokens.css
+++ b/projects/valtimo/user-interface/assets/design-tokens.css
@@ -188,7 +188,7 @@
   --v-table-pagination-size-spacing-inline: var(--v-spacing-inline-sm);
   --v-table-pagination-button-spacing-inline: var(--v-spacing-inline-2xl);
   /* select */
-  --v-select-background-color: var(--v-color-grey-4);
+  --v-select-background-color: var(--v-color-white);
   --v-select-selected-background-color: var(--v-color-grey-3);
   --v-select-highlighted-background-color: var(--v-color-grey-4);
   --v-select-disabled-font-color: var(--v-color-grey-2);

--- a/projects/valtimo/user-interface/src/lib/components/select/select.component.scss
+++ b/projects/valtimo/user-interface/src/lib/components/select/select.component.scss
@@ -22,9 +22,6 @@
   .ng-select.ng-select-opened > .ng-select-container {
     background: var(--v-select-background-color);
   }
-  .ng-select.ng-select-opened > .ng-select-container:hover {
-    box-shadow: none;
-  }
   .ng-select.ng-select-opened > .ng-select-container .ng-arrow {
     top: -2px;
     border-color: transparent transparent var(--v-select-arrow-hover-color);
@@ -51,7 +48,6 @@
   }
   .ng-select.ng-select-focused:not(.ng-select-opened) > .ng-select-container {
     border-color: transparent;
-    box-shadow: none;
   }
   .ng-select.ng-select-disabled > .ng-select-container {
     color: var(--v-select-disabled-font-color);
@@ -66,12 +62,10 @@
     color: var(--v-select-font-color);
     background-color: var(--v-select-background-color);
     border-radius: var(--v-select-border-radius);
+    box-shadow: var(--v-input-box-shadow);
     border: none;
     min-height: 36px;
     align-items: center;
-  }
-  .ng-select .ng-select-container:hover {
-    box-shadow: none;
   }
   .ng-select .ng-select-container .ng-value-container {
     align-items: center;

--- a/projects/valtimo/user-interface/src/lib/components/select/select.component.scss
+++ b/projects/valtimo/user-interface/src/lib/components/select/select.component.scss
@@ -51,6 +51,10 @@
   }
   .ng-select.ng-select-disabled > .ng-select-container {
     color: var(--v-select-disabled-font-color);
+    background: var(--v-select-disabled-bg-color);
+  }
+  .ng-select.ng-select-disabled .ng-arrow-wrapper {
+    pointer-events: none;
   }
   .ng-select .ng-has-value .ng-placeholder {
     display: none;
@@ -333,7 +337,7 @@
   }
   .ng-dropdown-panel .ng-dropdown-panel-items .ng-option.ng-option-selected,
   .ng-dropdown-panel .ng-dropdown-panel-items .ng-option.ng-option-selected.ng-option-marked {
-    color: var(--v-select-font-color);
+    color: var(--v-select-darker-font-color);
     background-color: var(--v-select-selected-background-color);
   }
   .ng-dropdown-panel .ng-dropdown-panel-items .ng-option.ng-option-selected .ng-option-label,


### PR DESCRIPTION
* change the select background color variable to white
* added shadow in selector for contrast
* removed hover from select when component disabled
* changed select background color when disabled
* added new color variables for the select component

US: https://ritense.tpondemand.com/entity/36692-fe-new-design-dropdown-seems-disabled