### PR TITLE
Add empty state if no documentInstance have been started yet

### DIFF
--- a/projects/valtimo/config/assets/core/de.json
+++ b/projects/valtimo/config/assets/core/de.json
@@ -70,6 +70,9 @@
     "userTasksDoneState": "Alles erledigt!",
     "taskLocked": "Kein Zugriff zu dieser Aufgabe!"
   },
+  "progress": {
+    "noProcessDocumentInstances": "Es wurde noch kein Prozess gestartet"
+  },
   "dashboard": {
     "openTasks": {
       "title": "Alle Aufgaben"

--- a/projects/valtimo/config/assets/core/en.json
+++ b/projects/valtimo/config/assets/core/en.json
@@ -70,6 +70,9 @@
     "userTasksDoneState": "All done!",
     "taskLocked": "You don't have access to this task"
   },
+  "progress": {
+    "noProcessDocumentInstances": "There is no process started yet"
+  },
   "dashboard": {
     "openTasks": {
       "title": "All tasks"

--- a/projects/valtimo/config/assets/core/nl.json
+++ b/projects/valtimo/config/assets/core/nl.json
@@ -70,6 +70,9 @@
     "userTasksDoneState": "Helemaal bij!",
     "taskLocked": "Je hebt geen toegang tot deze taak"
   },
+  "progress": {
+    "noProcessDocumentInstances": "Er is nog geen proces gestart"
+  },
   "dashboard": {
     "openTasks": {
       "title": "Alle taken"

--- a/projects/valtimo/dossier/src/lib/dossier-detail/tab/progress/progress.component.html
+++ b/projects/valtimo/dossier/src/lib/dossier-detail/tab/progress/progress.component.html
@@ -14,7 +14,8 @@
   ~ limitations under the License.
   -->
 
-<div class="full-height-tab-content" *ngIf="processDocumentInstances">
+<div class="full-height-tab-content"
+     *ngIf="processDocumentInstances && processDocumentInstances?.length > 0; else emptyProcessDocumentInstances">
   <div class="col-3">
     <label><strong>Process</strong></label
     ><br />
@@ -32,3 +33,7 @@
     [processInstanceId]="selectedProcessInstanceId"
   ></valtimo-process-diagram>
 </div>
+
+<ng-template #emptyProcessDocumentInstances>
+  <span> {{ 'progress.noProcessDocumentInstances' | translate }}</span>
+</ng-template>

--- a/projects/valtimo/dossier/src/lib/dossier-detail/tab/progress/progress.component.html
+++ b/projects/valtimo/dossier/src/lib/dossier-detail/tab/progress/progress.component.html
@@ -15,7 +15,7 @@
   -->
 
 <div class="full-height-tab-content"
-     *ngIf="processDocumentInstances && processDocumentInstances?.length > 0; else emptyProcessDocumentInstances">
+     *ngIf="processDocumentInstances && processDocumentInstances.length > 0; else emptyProcessDocumentInstances">
   <div class="col-3">
     <label><strong>Process</strong></label
     ><br />

--- a/projects/valtimo/dossier/src/lib/dossier-detail/tab/progress/progress.component.ts
+++ b/projects/valtimo/dossier/src/lib/dossier-detail/tab/progress/progress.component.ts
@@ -39,7 +39,9 @@ export class DossierDetailTabProgressComponent implements OnInit {
       .findProcessDocumentInstances(this.documentId)
       .subscribe(processDocumentInstances => {
         this.processDocumentInstances = processDocumentInstances;
-        this.selectedProcessInstanceId = processDocumentInstances[0].id.processInstanceId;
+        if (processDocumentInstances.length > 0) {
+          this.selectedProcessInstanceId = processDocumentInstances[0].id.processInstanceId;
+        }
       });
   }
 


### PR DESCRIPTION
We have a situation where we already have a case/dossier in Valtimo, but no active process yet since we start the process with sub process task. Right now Valtimo assumes that there is atleast one process active in the progress tab (or has been active) but for us that is not the case.