### PR TITLE
Add a option in the environment file to set the supported files types…

### DIFF
--- a/projects/valtimo/config/src/lib/models/config.ts
+++ b/projects/valtimo/config/src/lib/models/config.ts
@@ -86,6 +86,7 @@ export interface ValtimoConfig {
   };
   uploadProvider: UploadProvider;
   caseFileSizeUploadLimitMB?: number;
+  caseFileUploadAcceptedFiles?: string;
   defaultDefinitionTable: Array<DefinitionColumn>;
   customDefinitionTables: {
     [definitionNameId: string]: Array<DefinitionColumn>;

--- a/projects/valtimo/dossier/src/lib/dossier-detail/tab/openzaak-documents/openzaak-documents.component.html
+++ b/projects/valtimo/dossier/src/lib/dossier-detail/tab/openzaak-documents/openzaak-documents.component.html
@@ -16,7 +16,7 @@
 
 <valtimo-dropzone
   (fileSelected)="fileSelected($event)"
-  [acceptedFiles]="null"
+  [acceptedFiles]="acceptedFiles"
   [hideFilePreview]="true"
   [hideTitle]="true"
   [maxFileSize]="maxFileSize"

--- a/projects/valtimo/dossier/src/lib/dossier-detail/tab/openzaak-documents/openzaak-documents.component.ts
+++ b/projects/valtimo/dossier/src/lib/dossier-detail/tab/openzaak-documents/openzaak-documents.component.ts
@@ -33,6 +33,7 @@ export class DossierDetailTabOpenzaakDocumentsComponent implements OnInit {
   public readonly documentId: string;
   public readonly documentDefinitionName: string;
   public readonly maxFileSize: number = this.configService?.config?.caseFileSizeUploadLimitMB || 5;
+  public readonly acceptedFiles: string = this.configService?.config?.caseFileUploadAcceptedFiles || null;
   public fields = [
     {key: 'fileName', label: 'File name'},
     {key: 'sizeInBytes', label: 'Size in bytes'},

--- a/projects/valtimo/dossier/src/lib/dossier-detail/tab/s3-documents/s3-documents.component.html
+++ b/projects/valtimo/dossier/src/lib/dossier-detail/tab/s3-documents/s3-documents.component.html
@@ -16,7 +16,7 @@
 
 <valtimo-dropzone
   (fileSelected)="fileSelected($event)"
-  [acceptedFiles]="null"
+  [acceptedFiles]="acceptedFiles"
   [hideFilePreview]="true"
   [hideTitle]="true"
   [maxFileSize]="maxFileSize"

--- a/projects/valtimo/dossier/src/lib/dossier-detail/tab/s3-documents/s3-documents.component.ts
+++ b/projects/valtimo/dossier/src/lib/dossier-detail/tab/s3-documents/s3-documents.component.ts
@@ -33,6 +33,7 @@ export class DossierDetailTabS3DocumentsComponent implements OnInit {
   public readonly documentId: string;
   public readonly documentDefinitionName: string;
   public readonly maxFileSize: number = this.configService?.config?.caseFileSizeUploadLimitMB || 5;
+  public readonly acceptedFiles: string = this.configService?.config?.caseFileUploadAcceptedFiles || null;
   public fields = [
     {key: 'fileName', label: 'File name'},
     {key: 'sizeInBytes', label: 'Size in bytes'},


### PR DESCRIPTION
Currently all file types are enabled when uploading a file inside of the document tab. We are not allowed to support the ability to upload .exe or .bat files for a certain implementation. This is why I added a property to whitelist the specific types that are supported (the library that is being used doesn't support a blacklist).