### PR TITLE
Fixed bug which prevents viewing documents from the document tab in a…

### DIFF
--- a/projects/valtimo/config/src/lib/models/config.ts
+++ b/projects/valtimo/config/src/lib/models/config.ts
@@ -87,6 +87,7 @@ export interface ValtimoConfig {
   uploadProvider: UploadProvider;
   caseFileSizeUploadLimitMB?: number;
   caseFileUploadAcceptedFiles?: string;
+  supportedDocumentFileTypesToViewInBrowser?: string[];
   defaultDefinitionTable: Array<DefinitionColumn>;
   customDefinitionTables: {
     [definitionNameId: string]: Array<DefinitionColumn>;

--- a/projects/valtimo/resource/src/lib/services/download.service.ts
+++ b/projects/valtimo/resource/src/lib/services/download.service.ts
@@ -33,7 +33,7 @@ export class DownloadService {
       this.http.get(url, {responseType: 'blob'}).subscribe(content => {
         const downloadUrl = window.URL.createObjectURL(content);
         if (this.isFileTypeSupportedForNewWindow(name)) {
-          this.openBlobInNewTab(downloadUrl);
+          this.openBlobInNewTab(downloadUrl, name);
         } else {
           this.openDownloadLink(downloadUrl, name);
         }
@@ -48,14 +48,15 @@ export class DownloadService {
    * A window.open won't work for blobs because ad blocker extensions will immediately
    * close the tab again. The method used below will prevent this from happening.
    */
-  private openBlobInNewTab(url: string) {
+  private openBlobInNewTab(url: string, name: string) {
     const newWindow = window.open('/');
-    if (newWindow.document.readyState === 'complete') {
+
+    // newWindow file be null if the browsers blocks opening a new tab
+    if (newWindow != null) {
       newWindow.location = url;
     } else {
-      newWindow.onload = () => {
-        newWindow.location = url;
-      };
+      // In case the tab is blocked it will just download the file
+      this.openDownloadLink(url, name)
     }
   }
 
@@ -69,7 +70,7 @@ export class DownloadService {
   }
 
   private isFileTypeSupportedForNewWindow(name: string): boolean {
-    const supportedFileTypes = ['pdf', 'jpg', 'png', 'svg'];
+    const supportedFileTypes = this.configService?.config?.supportedDocumentFileTypesToViewInBrowser || ['pdf', 'jpg', 'png', 'svg'];
 
     return supportedFileTypes.some(function (suffix) {
       return name.toUpperCase().endsWith(suffix.toUpperCase());

--- a/projects/valtimo/resource/src/lib/services/download.service.ts
+++ b/projects/valtimo/resource/src/lib/services/download.service.ts
@@ -51,11 +51,11 @@ export class DownloadService {
   private openBlobInNewTab(url: string, name: string) {
     const newWindow = window.open('/');
 
-    // newWindow file be null if the browsers blocks opening a new tab
+    // newWindow will be null if the browser blocks the opening of a new tab.
     if (newWindow != null) {
       newWindow.location = url;
     } else {
-      // In case the tab is blocked it will just download the file
+      // In case the tab is blocked it will just download the file.
       this.openDownloadLink(url, name)
     }
   }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -159,6 +159,7 @@ export const environment: ValtimoConfig = {
   },
   uploadProvider: UploadProvider.DOCUMENTEN_API,
   caseFileSizeUploadLimitMB: 100,
+  supportedDocumentFileTypesToViewInBrowser: ['pdf', 'jpg', 'png', 'svg'],
   defaultDefinitionTable: defaultDefinitionColumns,
   customDefinitionTables: {
     leningen: [


### PR DESCRIPTION
Fixed bug which prevents viewing documents from the document tab in a new browser tab. Users that were using Firefox could not open any of the files that open in a new window. This has been resolved and I tested this on a mac for Chrome, Firefox, Safari and Microsoft Edge for mac (Not sure if this is exactly the same as the windows version). While working on this issue I also added the option in the environment file to set the extension that were hardcoded right now.