### PR TITLE
feat: get document types, use new upload endpoint

### DIFF
--- a/projects/valtimo/components/src/lib/components/documenten-api-metadata-modal/documenten-api-metadata-modal.component.html
+++ b/projects/valtimo/components/src/lib/components/documenten-api-metadata-modal/documenten-api-metadata-modal.component.html
@@ -101,6 +101,19 @@
         [widthInPx]="200"
         name="language"
       ></v-select>
+      <ng-container *ngIf="{documentTypeItems: documentTypeItems$ | async} as obs">
+        <v-select
+          [disabled]="obs.disabled"
+          [items]="obs.documentTypeItems"
+          [loading]="!obs.documentTypeItems"
+          [margin]="true"
+          [required]="true"
+          [title]="'document.informatieobjecttype' | translate"
+          [tooltip]="'document.informatieobjecttypeTooltip' | translate"
+          [widthInPx]="200"
+          name="informatieobjecttype"
+        ></v-select>
+      </ng-container>
       <v-date-picker
         [defaultDateIsToday]="true"
         [disabled]="obs.disabled"

--- a/projects/valtimo/components/src/lib/components/documenten-api-metadata-modal/documenten-api-metadata-modal.component.ts
+++ b/projects/valtimo/components/src/lib/components/documenten-api-metadata-modal/documenten-api-metadata-modal.component.ts
@@ -113,6 +113,8 @@ export class DocumentenApiMetadataModalComponent implements OnInit, OnDestroy {
   }
 
   hide(): void {
+    this.formData$.next(null);
+    this.valid$.next(false);
     this.modalService.closeModal();
   }
 

--- a/projects/valtimo/components/src/lib/components/documenten-api-metadata-modal/documenten-api-metadata-modal.component.ts
+++ b/projects/valtimo/components/src/lib/components/documenten-api-metadata-modal/documenten-api-metadata-modal.component.ts
@@ -16,7 +16,7 @@
 
 import {Component, Input, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {ModalComponent, ModalService, SelectItem} from '@valtimo/user-interface';
-import {BehaviorSubject, map, Observable, Subscription} from 'rxjs';
+import {BehaviorSubject, map, Observable, Subscription, switchMap, tap} from 'rxjs';
 import {
   ConfidentialityLevel,
   DocumentenApiMetadata,
@@ -24,6 +24,8 @@ import {
   DocumentStatus,
 } from '../../models';
 import {TranslateService} from '@ngx-translate/core';
+import {ActivatedRoute} from '@angular/router';
+import {DocumentService} from '@valtimo/document';
 
 @Component({
   selector: 'valtimo-documenten-api-metadata-modal',
@@ -81,6 +83,11 @@ export class DocumentenApiMetadataModalComponent implements OnInit, OnDestroy {
       }))
     )
   );
+  readonly documentTypeItems$: Observable<Array<SelectItem>> = this.route.params.pipe(
+    tap(routeParams => console.log(routeParams)),
+    switchMap(params => this.documentService.getDocumentTypes(params.documentDefinitionName)),
+    map(documentTypes => documentTypes.map(type => ({id: type.url, text: type.name})))
+  );
   readonly showForm$: Observable<boolean> = this.modalService.modalVisible$;
   readonly valid$ = new BehaviorSubject<boolean>(false);
   private showSubscription!: Subscription;
@@ -88,7 +95,9 @@ export class DocumentenApiMetadataModalComponent implements OnInit, OnDestroy {
 
   constructor(
     private readonly modalService: ModalService,
-    private readonly translateService: TranslateService
+    private readonly translateService: TranslateService,
+    private readonly route: ActivatedRoute,
+    private readonly documentService: DocumentService
   ) {}
 
   ngOnInit(): void {
@@ -125,7 +134,8 @@ export class DocumentenApiMetadataModalComponent implements OnInit, OnDestroy {
         data.author &&
         data.creationDate &&
         data.status &&
-        data.language
+        data.language &&
+        data.informatieobjecttype
       )
     );
   }

--- a/projects/valtimo/components/src/lib/models/documenten-api-metadata.model.ts
+++ b/projects/valtimo/components/src/lib/models/documenten-api-metadata.model.ts
@@ -39,6 +39,7 @@ interface DocumentenApiMetadata {
   receiptDate: string;
   sendDate: string;
   language: DocumentLanguage;
+  informatieobjecttype: string;
 }
 
 export {DocumentenApiMetadata, ConfidentialityLevel, DocumentStatus, DocumentLanguage};

--- a/projects/valtimo/config/assets/core/de.json
+++ b/projects/valtimo/config/assets/core/de.json
@@ -108,7 +108,9 @@
     "languageTooltip": "Die Sprache, in der das Dokument geschrieben ist",
     "nld": "Niederländisch",
     "eng": "Englisch",
-    "deu": "Deutsch"
+    "deu": "Deutsch",
+    "informatieobjecttype": "Dokumententyp",
+    "informatieobjecttypeTooltip": "Ein Dokumenttyp, der sich auf den Falltyp des aktuellen Falls bezieht"
   },
   "summary": {
     "userTasksDoneState": "Alles erledigt!",

--- a/projects/valtimo/config/assets/core/en.json
+++ b/projects/valtimo/config/assets/core/en.json
@@ -108,7 +108,9 @@
     "languageTooltip": "The language in which the document is written",
     "nld": "Dutch",
     "eng": "English",
-    "deu": "German"
+    "deu": "German",
+    "informatieobjecttype": "Document type",
+    "informatieobjecttypeTooltip": "A document type which is related to the zaak type of the current case"
   },
   "summary": {
     "userTasksDoneState": "All done!",

--- a/projects/valtimo/config/assets/core/nl.json
+++ b/projects/valtimo/config/assets/core/nl.json
@@ -108,7 +108,9 @@
     "languageTooltip": "De taal waarin het document is opgesteld",
     "nld": "Nederlands",
     "eng": "Engels",
-    "deu": "Duits"
+    "deu": "Duits",
+    "informatieobjecttype": "Documenttype",
+    "informatieobjecttypeTooltip": "Een documenttype dat gerelateerd is aan het zaaktype van het huidige dossier"
   },
   "summary": {
     "userTasksDoneState": "Helemaal bij!",

--- a/projects/valtimo/document/src/lib/document.service.ts
+++ b/projects/valtimo/document/src/lib/document.service.ts
@@ -26,6 +26,7 @@ import {
   DocumentResult,
   Documents,
   DocumentSendMessageRequest,
+  DocumentType,
   ModifyDocumentAndCompleteTaskRequestImpl,
   ModifyDocumentAndCompleteTaskResult,
   ModifyDocumentAndStartProcessRequestImpl,
@@ -216,5 +217,11 @@ export class DocumentService {
 
   sendMessage(documentId: string, request: DocumentSendMessageRequest): Observable<any> {
     return this.http.post(`${this.valtimoEndpointUri}document/${documentId}/message`, request);
+  }
+
+  getDocumentTypes(documentDefinitionName: string): Observable<Array<DocumentType>> {
+    return this.http.get<Array<DocumentType>>(
+      `${this.valtimoEndpointUri}documentdefinition/${documentDefinitionName}/zaaktype/documenttype`
+    );
   }
 }

--- a/projects/valtimo/document/src/lib/models/document.model.ts
+++ b/projects/valtimo/document/src/lib/models/document.model.ts
@@ -267,3 +267,8 @@ export interface DocumentRoles {
 export interface DocumentRole {
   name: string;
 }
+
+export interface DocumentType {
+  url: string;
+  name: string;
+}

--- a/projects/valtimo/dossier/src/lib/dossier-detail/tab/documenten-api-documents/documenten-api-documents.component.html
+++ b/projects/valtimo/dossier/src/lib/dossier-detail/tab/documenten-api-documents/documenten-api-documents.component.html
@@ -45,6 +45,7 @@
 </valtimo-widget>
 
 <valtimo-documenten-api-metadata-modal
+  (metadata)="metadataSet($event)"
   [disabled$]="modalDisabled$"
   [file$]="fileToBeUploaded$"
   [hide$]="hideModal$"

--- a/projects/valtimo/dossier/src/lib/dossier-detail/tab/documenten-api-documents/documenten-api-documents.component.ts
+++ b/projects/valtimo/dossier/src/lib/dossier-detail/tab/documenten-api-documents/documenten-api-documents.component.ts
@@ -153,7 +153,6 @@ export class DossierDetailTabDocumentenApiDocumentsComponent implements OnInit {
           this.uploadProviderService
             .uploadFileWithMetadata(file, this.documentId, metadata)
             .subscribe(res => {
-              console.log('res', res);
               this.uploading$.next(false);
               this.fileToBeUploaded$.next(null);
             });

--- a/projects/valtimo/dossier/src/lib/dossier-detail/tab/documenten-api-documents/documenten-api-documents.component.ts
+++ b/projects/valtimo/dossier/src/lib/dossier-detail/tab/documenten-api-documents/documenten-api-documents.component.ts
@@ -19,10 +19,11 @@ import {ActivatedRoute} from '@angular/router';
 import {DocumentService, RelatedFile} from '@valtimo/document';
 import {DownloadService, ResourceDto, UploadProviderService} from '@valtimo/resource';
 import {ToastrService} from 'ngx-toastr';
-import {map, switchMap} from 'rxjs/operators';
+import {map, switchMap, take, tap} from 'rxjs/operators';
 import {BehaviorSubject, combineLatest, Observable, Subject} from 'rxjs';
 import {TranslateService} from '@ngx-translate/core';
 import {ConfigService} from '@valtimo/config';
+import {DocumentenApiMetadata} from '@valtimo/components';
 
 @Component({
   selector: 'valtimo-dossier-detail-tab-documenten-api-documents',
@@ -139,6 +140,26 @@ export class DossierDetailTabDocumentenApiDocumentsComponent implements OnInit {
         this.toastrService.error('Failed to remove document from dossier');
       }
     );
+  }
+
+  metadataSet(metadata: DocumentenApiMetadata): void {
+    this.uploading$.next(true);
+    this.hideModal$.next(null);
+
+    this.fileToBeUploaded$
+      .pipe(take(1))
+      .pipe(
+        tap(file => {
+          this.uploadProviderService
+            .uploadFileWithMetadata(file, this.documentId, metadata)
+            .subscribe(res => {
+              console.log('res', res);
+              this.uploading$.next(false);
+              this.fileToBeUploaded$.next(null);
+            });
+        })
+      )
+      .subscribe();
   }
 
   private refetchDocuments(): void {

--- a/projects/valtimo/resource/src/lib/models/upload.model.ts
+++ b/projects/valtimo/resource/src/lib/models/upload.model.ts
@@ -42,4 +42,5 @@ export interface ResourceFile {
 export interface UploadService {
   uploadFile(file: File, documentDefinitionName?: string): Observable<ResourceFile>;
   getResource(resourceId: string): Observable<ResourceDto>;
+  uploadFileWithMetadata?(file: File, metadata: {[key: string]: any}): Observable<void>;
 }

--- a/projects/valtimo/resource/src/lib/models/upload.model.ts
+++ b/projects/valtimo/resource/src/lib/models/upload.model.ts
@@ -42,5 +42,9 @@ export interface ResourceFile {
 export interface UploadService {
   uploadFile(file: File, documentDefinitionName?: string): Observable<ResourceFile>;
   getResource(resourceId: string): Observable<ResourceDto>;
-  uploadFileWithMetadata?(file: File, metadata: {[key: string]: any}): Observable<void>;
+  uploadFileWithMetadata?(
+    file: File,
+    documentId: string,
+    metadata: {[key: string]: any}
+  ): Observable<void>;
 }

--- a/projects/valtimo/resource/src/lib/services/open-zaak-upload.service.ts
+++ b/projects/valtimo/resource/src/lib/services/open-zaak-upload.service.ts
@@ -40,9 +40,14 @@ export class OpenZaakUploadService implements UploadService {
       .pipe(map(result => this.getResourceFile(result)));
   }
 
-  uploadFileWithMetadata(file: File, metadata: {[key: string]: any}): Observable<void> {
+  uploadFileWithMetadata(
+    file: File,
+    documentId: string,
+    metadata: {[key: string]: any}
+  ): Observable<void> {
     return this.openZaakService.uploadWithMetadata(
       new File([file], file.name, {type: file.type}),
+      documentId,
       metadata
     );
   }

--- a/projects/valtimo/resource/src/lib/services/open-zaak-upload.service.ts
+++ b/projects/valtimo/resource/src/lib/services/open-zaak-upload.service.ts
@@ -18,7 +18,7 @@ import {Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {ConfigService} from '@valtimo/config';
 import {Observable} from 'rxjs';
-import {OpenZaakResource, ResourceFile, UploadService, ResourceDto} from '../models';
+import {OpenZaakResource, ResourceDto, ResourceFile, UploadService} from '../models';
 import {OpenZaakService} from './open-zaak.service';
 import {map} from 'rxjs/operators';
 
@@ -38,6 +38,13 @@ export class OpenZaakUploadService implements UploadService {
     return this.openZaakService
       .upload(new File([file], file.name, {type: file.type}), documentDefinitionName)
       .pipe(map(result => this.getResourceFile(result)));
+  }
+
+  uploadFileWithMetadata(file: File, metadata: {[key: string]: any}): Observable<void> {
+    return this.openZaakService.uploadWithMetadata(
+      new File([file], file.name, {type: file.type}),
+      metadata
+    );
   }
 
   getResource(resourceId: string): Observable<ResourceDto> {

--- a/projects/valtimo/resource/src/lib/services/open-zaak.service.ts
+++ b/projects/valtimo/resource/src/lib/services/open-zaak.service.ts
@@ -152,4 +152,15 @@ export class OpenZaakService {
       }
     );
   }
+
+  uploadWithMetadata(file: File, metadata: {[key: string]: any}): Observable<void> {
+    const formData: FormData = new FormData();
+    formData.append('file', file);
+    formData.append('metaData', metadata.toString());
+
+    return this.http.post<void>(`${this.valtimoApiConfig.endpointUri}resource/temp`, formData, {
+      reportProgress: true,
+      responseType: 'json',
+    });
+  }
 }

--- a/projects/valtimo/resource/src/lib/services/open-zaak.service.ts
+++ b/projects/valtimo/resource/src/lib/services/open-zaak.service.ts
@@ -153,10 +153,18 @@ export class OpenZaakService {
     );
   }
 
-  uploadWithMetadata(file: File, metadata: {[key: string]: any}): Observable<void> {
+  uploadWithMetadata(
+    file: File,
+    documentId: string,
+    metadata: {[key: string]: any}
+  ): Observable<void> {
     const formData: FormData = new FormData();
     formData.append('file', file);
-    formData.append('metaData', metadata.toString());
+    formData.append('documentId', documentId);
+
+    Object.keys(metadata).forEach(metaDataKey => {
+      formData.append(metaDataKey, metadata[metaDataKey] || null);
+    });
 
     return this.http.post<void>(`${this.valtimoApiConfig.endpointUri}resource/temp`, formData, {
       reportProgress: true,

--- a/projects/valtimo/resource/src/lib/services/upload-provider.service.ts
+++ b/projects/valtimo/resource/src/lib/services/upload-provider.service.ts
@@ -18,7 +18,7 @@ import {Injectable, Injector} from '@angular/core';
 import {NGXLogger} from 'ngx-logger';
 import {ResourceDto, ResourceFile, UploadService} from '../models';
 import {ConfigService, UploadProvider} from '@valtimo/config';
-import {Observable} from 'rxjs';
+import {Observable, of} from 'rxjs';
 import {OpenZaakUploadService} from './open-zaak-upload.service';
 import {S3UploadService} from './s3-upload.service';
 
@@ -57,5 +57,13 @@ export class UploadProviderService implements UploadService {
 
   getResource(resourceId: string): Observable<ResourceDto> {
     return this.uploadService.getResource(resourceId);
+  }
+
+  uploadFileWithMetadata(file: File, metadata: {[key: string]: any}): Observable<void> {
+    if (this.uploadService.uploadFileWithMetadata) {
+      return this.uploadService.uploadFileWithMetadata(file, metadata);
+    } else {
+      return of(null);
+    }
   }
 }

--- a/projects/valtimo/resource/src/lib/services/upload-provider.service.ts
+++ b/projects/valtimo/resource/src/lib/services/upload-provider.service.ts
@@ -59,9 +59,13 @@ export class UploadProviderService implements UploadService {
     return this.uploadService.getResource(resourceId);
   }
 
-  uploadFileWithMetadata(file: File, metadata: {[key: string]: any}): Observable<void> {
+  uploadFileWithMetadata(
+    file: File,
+    documentId: string,
+    metadata: {[key: string]: any}
+  ): Observable<void> {
     if (this.uploadService.uploadFileWithMetadata) {
-      return this.uploadService.uploadFileWithMetadata(file, metadata);
+      return this.uploadService.uploadFileWithMetadata(file, documentId, metadata);
     } else {
       return of(null);
     }


### PR DESCRIPTION
Also uses new upload endpoint. Closes https://ritense.tpondemand.com/entity/37438-fe-get-document-types-from-catalogi 