### PR TITLE
Add prompt when deleting files

### DIFF
--- a/projects/valtimo/config/assets/core/de.json
+++ b/projects/valtimo/config/assets/core/de.json
@@ -66,7 +66,13 @@
         "adminRole": "Der Prozess zum Hochladen von Dokumenten wurde nicht konfiguriert. Bitte konfigurieren Sie diesen Prozess auf der Fallverwaltungsseite"
       }
   },
-    "startSubProcess": "Starten"
+    "startSubProcess": "Starten",
+    "deleteConfirmation": {
+      "title": "Datei löschen",
+      "description": "Möchten Sie diese Datei wirklich löschen?",
+      "cancel": "Absagen",
+      "delete": "Löschen"
+    }
   },
   "document": {
     "title": {

--- a/projects/valtimo/config/assets/core/en.json
+++ b/projects/valtimo/config/assets/core/en.json
@@ -66,7 +66,13 @@
         "adminRole": "The process for uploading documents has not been configured. Please configure this process on the case management page"
       }
     },
-    "startSubProcess": "Start"
+    "startSubProcess": "Start",
+    "deleteConfirmation": {
+      "title": "Delete file",
+      "description": "Are you sure you want to delete this file?",
+      "cancel": "Cancel",
+      "delete": "Delete"
+    }
   },
   "document": {
     "title": {

--- a/projects/valtimo/config/assets/core/nl.json
+++ b/projects/valtimo/config/assets/core/nl.json
@@ -66,7 +66,13 @@
         "adminRole": "Het proces voor het uploaden van documenten is niet geconfigureerd. Configureer dit proces op de casebeheerpagina"
       }
     },
-    "startSubProcess": "Start"
+    "startSubProcess": "Start",
+    "deleteConfirmation": {
+      "title": "Bestand verwijderen",
+      "description": "Weet u zeker dat u dit bestand wilt verwijderen?",
+      "cancel": "Annuleren",
+      "delete": "Verwijderen"
+    }
   },
   "document": {
     "title": {

--- a/projects/valtimo/dossier/src/lib/dossier-detail/tab/documenten-api-documents/documenten-api-documents.component.ts
+++ b/projects/valtimo/dossier/src/lib/dossier-detail/tab/documenten-api-documents/documenten-api-documents.component.ts
@@ -25,6 +25,7 @@ import {TranslateService} from '@ngx-translate/core';
 import {ConfigService} from '@valtimo/config';
 import {DocumentenApiMetadata} from '@valtimo/components';
 import {UserProviderService} from '@valtimo/security';
+import {PromptService} from '@valtimo/user-interface';
 
 @Component({
   selector: 'valtimo-dossier-detail-tab-documenten-api-documents',
@@ -87,6 +88,7 @@ export class DossierDetailTabDocumentenApiDocumentsComponent implements OnInit {
     private readonly toastrService: ToastrService,
     private readonly uploadProviderService: UploadProviderService,
     private readonly downloadService: DownloadService,
+    private readonly promptService: PromptService,
     private readonly translateService: TranslateService,
     private readonly configService: ConfigService,
     private readonly userProviderService: UserProviderService
@@ -136,16 +138,30 @@ export class DossierDetailTabDocumentenApiDocumentsComponent implements OnInit {
       });
   }
 
-  removeRelatedFile(relatedFile: RelatedFile): void {
-    this.documentService.removeResource(this.documentId, relatedFile.fileId).subscribe(
-      () => {
-        this.toastrService.success('Successfully removed document from dossier');
-        this.refetchDocuments();
-      },
-      () => {
-        this.toastrService.error('Failed to remove document from dossier');
+  removeRelatedFile(relatedFile: RelatedFile) {
+    this.promptService.openPrompt({
+      headerText: this.translateService.instant('dossier.deleteConfirmation.title'),
+      bodyText: this.translateService.instant('dossier.deleteConfirmation.description'),
+      cancelButtonText: this.translateService.instant('dossier.deleteConfirmation.cancel'),
+      confirmButtonText: this.translateService.instant('dossier.deleteConfirmation.delete'),
+      cancelMdiIcon: 'cancel',
+      confirmMdiIcon: 'delete',
+      cancelButtonType: 'secondary',
+      confirmButtonType: 'primary',
+      closeOnConfirm: true,
+      closeOnCancel: true,
+      confirmCallBackFunction: () => {
+        this.documentService.removeResource(this.documentId, relatedFile.fileId).subscribe(
+          () => {
+            this.toastrService.success('Successfully removed document from dossier');
+            this.refetchDocuments();
+          },
+          () => {
+            this.toastrService.error('Failed to remove document from dossier');
+          }
+        );
       }
-    );
+    })
   }
 
   metadataSet(metadata: DocumentenApiMetadata): void {

--- a/projects/valtimo/dossier/src/lib/dossier-detail/tab/documenten-api-documents/documenten-api-documents.component.ts
+++ b/projects/valtimo/dossier/src/lib/dossier-detail/tab/documenten-api-documents/documenten-api-documents.component.ts
@@ -161,7 +161,7 @@ export class DossierDetailTabDocumentenApiDocumentsComponent implements OnInit {
           }
         );
       }
-    })
+    });
   }
 
   metadataSet(metadata: DocumentenApiMetadata): void {

--- a/projects/valtimo/dossier/src/lib/dossier-detail/tab/s3-documents/s3-documents.component.ts
+++ b/projects/valtimo/dossier/src/lib/dossier-detail/tab/s3-documents/s3-documents.component.ts
@@ -23,6 +23,7 @@ import {map, switchMap} from 'rxjs/operators';
 import {BehaviorSubject, combineLatest, Observable} from 'rxjs';
 import {TranslateService} from '@ngx-translate/core';
 import {ConfigService} from '@valtimo/config';
+import {PromptService} from '@valtimo/user-interface';
 
 @Component({
   selector: 'valtimo-dossier-detail-tab-s3-documents',
@@ -78,6 +79,7 @@ export class DossierDetailTabS3DocumentsComponent implements OnInit {
     private readonly toastrService: ToastrService,
     private readonly uploadProviderService: UploadProviderService,
     private readonly downloadService: DownloadService,
+    private readonly promptService: PromptService,
     private readonly translateService: TranslateService,
     private readonly configService: ConfigService
   ) {
@@ -121,16 +123,30 @@ export class DossierDetailTabS3DocumentsComponent implements OnInit {
       });
   }
 
-  removeRelatedFile(relatedFile: RelatedFile): void {
-    this.documentService.removeResource(this.documentId, relatedFile.fileId).subscribe(
-      () => {
-        this.toastrService.success('Successfully removed document from dossier');
-        this.refetchDocuments();
-      },
-      () => {
-        this.toastrService.error('Failed to remove document from dossier');
+  removeRelatedFile(relatedFile: RelatedFile) {
+    this.promptService.openPrompt({
+      headerText: this.translateService.instant('dossier.deleteConfirmation.title'),
+      bodyText: this.translateService.instant('dossier.deleteConfirmation.description'),
+      cancelButtonText: this.translateService.instant('dossier.deleteConfirmation.cancel'),
+      confirmButtonText: this.translateService.instant('dossier.deleteConfirmation.delete'),
+      cancelMdiIcon: 'cancel',
+      confirmMdiIcon: 'delete',
+      cancelButtonType: 'secondary',
+      confirmButtonType: 'primary',
+      closeOnConfirm: true,
+      closeOnCancel: true,
+      confirmCallBackFunction: () => {
+        this.documentService.removeResource(this.documentId, relatedFile.fileId).subscribe(
+          () => {
+            this.toastrService.success('Successfully removed document from dossier');
+            this.refetchDocuments();
+          },
+          () => {
+            this.toastrService.error('Failed to remove document from dossier');
+          }
+        );
       }
-    );
+    })
   }
 
   private refetchDocuments(): void {

--- a/projects/valtimo/dossier/src/lib/dossier-detail/tab/s3-documents/s3-documents.component.ts
+++ b/projects/valtimo/dossier/src/lib/dossier-detail/tab/s3-documents/s3-documents.component.ts
@@ -146,7 +146,7 @@ export class DossierDetailTabS3DocumentsComponent implements OnInit {
           }
         );
       }
-    })
+    });
   }
 
   private refetchDocuments(): void {

--- a/projects/valtimo/user-interface/src/lib/components/button/button.component.ts
+++ b/projects/valtimo/user-interface/src/lib/components/button/button.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Component, Output, EventEmitter, Input, OnInit} from '@angular/core';
+import {Component, Output, EventEmitter, Input, OnInit, SimpleChanges, OnChanges} from '@angular/core';
 import {ButtonType} from '../../models';
 
 @Component({
@@ -22,7 +22,7 @@ import {ButtonType} from '../../models';
   templateUrl: './button.component.html',
   styleUrls: ['./button.component.scss'],
 })
-export class ButtonComponent implements OnInit {
+export class ButtonComponent implements OnInit, OnChanges {
   @Input() type: ButtonType = 'primary';
   @Input() mdiIcon!: string;
   @Input() disabled!: boolean;
@@ -42,6 +42,12 @@ export class ButtonComponent implements OnInit {
 
   ngOnInit(): void {
     this.setIconTypes();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes?.type || changes?.mdiIcon) {
+      this.setIconTypes();
+    }
   }
 
   buttonClick(): void {

--- a/projects/valtimo/user-interface/src/lib/components/prompt/prompt.component.html
+++ b/projects/valtimo/user-interface/src/lib/components/prompt/prompt.component.html
@@ -69,14 +69,16 @@
         [disabled]="appearing || disappearing"
         (clickEvent)="cancel()"
         [mdiIcon]="(cancelMdiIcon$ | async) || 'cancel'"
-        >{{ cancelText$ | async }}</v-button
-      >
+        [type]="(cancelButtonType$ | async) || 'primary'"
+        >{{ cancelText$ | async }}
+      </v-button>
       <v-button
         [disabled]="appearing || disappearing"
         (clickEvent)="confirm()"
         [mdiIcon]="(confirmMdiIcon$ | async) || 'check'"
-        >{{ confirmText$ | async }}</v-button
-      >
+        [type]="(confirmButtonType$ | async) || 'primary'"
+        >{{ confirmText$ | async }}
+      </v-button>
     </div>
   </div>
 </ng-template>

--- a/projects/valtimo/user-interface/src/lib/components/prompt/prompt.component.ts
+++ b/projects/valtimo/user-interface/src/lib/components/prompt/prompt.component.ts
@@ -41,6 +41,8 @@ export class PromptComponent implements OnInit {
   readonly confirmText$ = this.promptService.confirmText$;
   readonly cancelMdiIcon$ = this.promptService.cancelMdiIcon$;
   readonly confirmMdiIcon$ = this.promptService.confirmMdiIcon$;
+  readonly cancelButtonType$ = this.promptService.cancelButtonType$;
+  readonly confirmButtonType$ = this.promptService.confirmButtonType$;
 
   constructor(private readonly promptService: PromptService) {}
 

--- a/projects/valtimo/user-interface/src/lib/services/prompt.service.ts
+++ b/projects/valtimo/user-interface/src/lib/services/prompt.service.ts
@@ -17,6 +17,7 @@
 import {Injectable} from '@angular/core';
 import {BehaviorSubject, Observable, combineLatest} from 'rxjs';
 import {take} from 'rxjs/operators';
+import {ButtonType} from '../models';
 
 @Injectable({
   providedIn: 'root',
@@ -26,12 +27,15 @@ export class PromptService {
   private readonly _appearing$ = new BehaviorSubject<boolean>(false);
   private readonly _disappearing$ = new BehaviorSubject<boolean>(false);
   private readonly _appearingDelayMs$ = new BehaviorSubject<number>(140);
+  private readonly _identifier$ = new BehaviorSubject<string>('');
   private readonly _headerText$ = new BehaviorSubject<string>('');
   private readonly _bodyText$ = new BehaviorSubject<string>('');
   private readonly _cancelText$ = new BehaviorSubject<string>('');
   private readonly _confirmText$ = new BehaviorSubject<string>('');
   private readonly _cancelMdiIcon$ = new BehaviorSubject<string>('');
   private readonly _confirmMdiIcon$ = new BehaviorSubject<string>('');
+  private readonly _cancelButtonType$ = new BehaviorSubject<ButtonType>('primary');
+  private readonly _confirmButtonType$ = new BehaviorSubject<ButtonType>('primary');
   private readonly _closeOnConfirm$ = new BehaviorSubject<boolean>(false);
   private readonly _closeOnCancel$ = new BehaviorSubject<boolean>(false);
   private readonly _cancelCallbackFunction$ = new BehaviorSubject<() => void>(() => {});
@@ -55,6 +59,10 @@ export class PromptService {
 
   get appearingDelayMs() {
     return this._appearingDelayMs$.getValue();
+  }
+
+  get identifier$(): Observable<string> {
+    return this._identifier$.asObservable();
   }
 
   get headerText$(): Observable<string> {
@@ -81,18 +89,31 @@ export class PromptService {
     return this._confirmMdiIcon$.asObservable();
   }
 
+  get cancelButtonType$(): Observable<ButtonType> {
+    return this._cancelButtonType$.asObservable();
+  }
+
+  get confirmButtonType$(): Observable<ButtonType> {
+    return this._confirmButtonType$.asObservable();
+  }
+
   openPrompt(promptParameters: {
+    identifier?: string;
     headerText: string;
     bodyText: string;
     cancelButtonText: string;
     confirmButtonText: string;
     cancelMdiIcon?: string;
     confirmMdiIcon?: string;
+    cancelButtonType?: ButtonType;
+    confirmButtonType?: ButtonType;
     closeOnConfirm?: boolean;
     closeOnCancel?: boolean;
     cancelCallbackFunction?: () => void;
     confirmCallBackFunction?: () => void;
   }): void {
+    if (promptParameters.identifier)
+      this._identifier$.next(promptParameters.identifier);
     this._headerText$.next(promptParameters.headerText);
     this._bodyText$.next(promptParameters.bodyText);
     this._cancelText$.next(promptParameters.cancelButtonText);
@@ -100,6 +121,10 @@ export class PromptService {
     if (promptParameters.cancelMdiIcon) this._cancelMdiIcon$.next(promptParameters.cancelMdiIcon);
     if (promptParameters.confirmMdiIcon)
       this._confirmMdiIcon$.next(promptParameters.confirmMdiIcon);
+    if (promptParameters.cancelButtonType)
+      this._cancelButtonType$.next(promptParameters.cancelButtonType);
+    if (promptParameters.confirmButtonType)
+      this._confirmButtonType$.next(promptParameters.confirmButtonType);
     if (promptParameters.closeOnConfirm)
       this._closeOnConfirm$.next(promptParameters.closeOnConfirm);
     if (promptParameters.closeOnCancel) this._closeOnCancel$.next(promptParameters.closeOnCancel);
@@ -172,12 +197,15 @@ export class PromptService {
   }
 
   private clear(): void {
+    this._identifier$.next('');
     this._headerText$.next('');
     this._bodyText$.next('');
     this._cancelText$.next('');
     this._confirmText$.next('');
     this._cancelMdiIcon$.next('');
     this._confirmMdiIcon$.next('');
+    this._cancelButtonType$.next('primary');
+    this._confirmButtonType$.next('primary');
     this._closeOnCancel$.next(false);
     this._closeOnConfirm$.next(false);
     this._cancelCallbackFunction$.next(() => {});

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -155,9 +155,9 @@ export const environment: ValtimoConfig = {
     dossiers: [],
   },
   openZaak: {
-    catalogus: '4d1644b3-70e7-4397-91b4-0b8ac1a8b765',
+    catalogus: '8225508a-6840-413e-acc9-6422af120db1',
   },
-  uploadProvider: UploadProvider.OPEN_ZAAK,
+  uploadProvider: UploadProvider.DOCUMENTEN_API,
   caseFileSizeUploadLimitMB: 100,
   supportedDocumentFileTypesToViewInBrowser: ['pdf', 'jpg', 'png', 'svg'],
   defaultDefinitionTable: defaultDefinitionColumns,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -155,9 +155,9 @@ export const environment: ValtimoConfig = {
     dossiers: [],
   },
   openZaak: {
-    catalogus: '8225508a-6840-413e-acc9-6422af120db1',
+    catalogus: '4d1644b3-70e7-4397-91b4-0b8ac1a8b765',
   },
-  uploadProvider: UploadProvider.DOCUMENTEN_API,
+  uploadProvider: UploadProvider.OPEN_ZAAK,
   caseFileSizeUploadLimitMB: 100,
   supportedDocumentFileTypesToViewInBrowser: ['pdf', 'jpg', 'png', 'svg'],
   defaultDefinitionTable: defaultDefinitionColumns,


### PR DESCRIPTION
Add prompt when deleting a file, fixed a bug with the keycloak prompt always overriding the body text and added the option to show different types of buttons in the prompt.
The story for this feature: https://ritense.tpondemand.com/restui/board.aspx?#page=userstory/3711037110