### PR TITLE
feat: check if upload process link is checked inside new formio component

### DIFF
--- a/projects/valtimo/components/src/lib/components/form-io/documenten-api-uploader/documenten-api-uploader.component.html
+++ b/projects/valtimo/components/src/lib/components/form-io/documenten-api-uploader/documenten-api-uploader.component.html
@@ -14,20 +14,34 @@
   ~ limitations under the License.
   -->
 
-<valtimo-dropzone
-  (fileSelected)="fileSelected($event)"
-  [acceptedFiles]="null"
-  [camera]="camera"
-  [disabled]="disabled"
-  [hideFilePreview]="true"
-  [hideTitle]="hideTitle"
-  [maxFileSize]="maxFileSize"
-  [maxFiles]="1"
-  [showMaxFileSize]="!hideMaxFileSize"
-  [subtitle]="subtitle"
-  [title]="title"
-  [uploading]="uploading$ | async"
-></valtimo-dropzone>
+<ng-container *ngIf="{linked: uploadProcessLinked$ | async, isAdmin: isAdmin$ | async} as obs">
+  <div *ngIf="obs.linked === false">
+    <div
+      *ngIf="obs.isAdmin"
+      [translate]="'dossier.documenten.noProcessLinked.adminRole'"
+      class="bg-warning text-black mb-2 p-3 text-center"
+    ></div>
+    <div
+      *ngIf="!obs.isAdmin"
+      [translate]="'dossier.documenten.noProcessLinked.regularUser'"
+      class="bg-warning text-black mb-2 p-3 text-center"
+    ></div>
+  </div>
+  <valtimo-dropzone
+    (fileSelected)="fileSelected($event)"
+    [acceptedFiles]="null"
+    [camera]="camera"
+    [disabled]="disabled || obs.linked === false || obs.linked === 'loading'"
+    [hideFilePreview]="true"
+    [hideTitle]="hideTitle"
+    [maxFileSize]="maxFileSize"
+    [maxFiles]="1"
+    [showMaxFileSize]="!hideMaxFileSize"
+    [subtitle]="subtitle"
+    [title]="title"
+    [uploading]="uploading$ | async"
+  ></valtimo-dropzone>
+</ng-container>
 
 <div *ngFor="let resource of _value" class="file-preview">
   <div class="file-preview-name">

--- a/projects/valtimo/components/src/lib/components/form-io/documenten-api-uploader/documenten-api-uploader.formio.ts
+++ b/projects/valtimo/components/src/lib/components/form-io/documenten-api-uploader/documenten-api-uploader.formio.ts
@@ -29,7 +29,7 @@ const COMPONENT_OPTIONS: FormioCustomComponentInfo = {
   type: customDocumentApiUploaderType,
   selector: 'documenten-api-form-io-uploader',
   title: 'Documenten API File Upload',
-  group: 'basic',
+  group: 'advanced',
   icon: 'upload',
   // set empty value to force formio to accept arrays as valid input value for this field type
   emptyValue: [],


### PR DESCRIPTION
Also changes category of formio component from basic to advanced. Closes https://ritense.tpondemand.com/entity/37552-fe-add-check-in-new-documenten and https://ritense.tpondemand.com/entity/37554-fe-move-documenten-api-formio-upload