### PR TITLE
Add the ability to set a separator key to add for example a format of…

### DIFF
--- a/projects/valtimo/components/src/lib/components/view-content/type-converters/dateTypeConverter.ts
+++ b/projects/valtimo/components/src/lib/components/view-content/type-converters/dateTypeConverter.ts
@@ -29,6 +29,6 @@ export class DateTypeConverter implements TypeConverter {
       return '-';
     }
 
-    return moment(value).format(definition.format != null && definition.format !== '' ? definition.format : 'DD-MM-YYYY, hh:mm A');
+    return moment(value).format(definition?.format || 'DD-MM-YYYY, hh:mm A');
   }
 }

--- a/projects/valtimo/components/src/lib/components/view-content/type-converters/dateTypeConverter.ts
+++ b/projects/valtimo/components/src/lib/components/view-content/type-converters/dateTypeConverter.ts
@@ -28,6 +28,7 @@ export class DateTypeConverter implements TypeConverter {
     if (!value) {
       return '-';
     }
-    return moment(value).format('DD-MM-YYYY, hh:mm A');
+
+    return moment(value).format(definition.format != null && definition.format !== '' ? definition.format : 'DD-MM-YYYY, hh:mm A');
   }
 }

--- a/projects/valtimo/components/src/lib/components/view-content/view-content.service.ts
+++ b/projects/valtimo/components/src/lib/components/view-content/view-content.service.ts
@@ -39,10 +39,10 @@ export class ViewContentService {
 
     if (definition.viewType.includes(separator)) {
       // Get the substring of the string after the separator (:) and assign it to a new key
-      definition.format = definition.viewType.slice(this.getIndexSeparator(definition, separator) + 1);
+      definition.format = definition.viewType.slice(this.getSeparatorIndex(definition, separator) + 1);
 
       // Remove the substring after the separator and the separator from the string and assign it back to the viewType
-      definition.viewType = definition.viewType.slice(0, this.getIndexSeparator(definition, separator));
+      definition.viewType = definition.viewType.slice(0, this.getSeparatorIndex(definition, separator));
     }
 
     if (typeof this.converters[definition.viewType] !== 'undefined') {
@@ -60,7 +60,7 @@ export class ViewContentService {
     this.converters[converter.getTypeString()] = converter;
   }
 
-  getIndexSeparator(definition, separator) {
+  getSeparatorIndex(definition, separator) {
     return definition.viewType.indexOf(separator);
   }
 }

--- a/projects/valtimo/components/src/lib/components/view-content/view-content.service.ts
+++ b/projects/valtimo/components/src/lib/components/view-content/view-content.service.ts
@@ -32,8 +32,17 @@ export class ViewContentService {
   }
 
   public get(value: any, definition: any) {
+    const separator = ':'
     if (!definition.viewType) {
       definition.viewType = typeof value;
+    }
+
+    if (definition.viewType.includes(separator)) {
+      // Get the substring of the string after the separator (:) and assign it to a new key
+      definition.format = definition.viewType.slice(this.getIndexSeparator(definition, separator) + 1);
+
+      // Remove the substring after the separator and the separator from the string and assign it back to the viewType
+      definition.viewType = definition.viewType.slice(0, this.getIndexSeparator(definition, separator));
     }
 
     if (typeof this.converters[definition.viewType] !== 'undefined') {
@@ -49,5 +58,9 @@ export class ViewContentService {
     }
 
     this.converters[converter.getTypeString()] = converter;
+  }
+
+  getIndexSeparator(definition, separator) {
+    return definition.viewType.indexOf(separator);
   }
 }


### PR DESCRIPTION
For Allnex we would like to have the ability to only show a date without any timestamp in the Valtimo list screens. Currently the dateConverter has a hardcoded format and can not be changed. If have add some code to the existing function which includes a check on a separator : (which is hardcoded). A couple of working examples would be:
viewType: "date:MM-DD-YYYY";
viewType: "date:MM:DD:YYYY";
viewType: "date: MM DD YYYY";
viewType: "date";

Of course you can put any format that moment uses as long as you start with : after the date.
The format is not mandatory and completely optional and won't breaking existing viewTypes.

I also saw this ticket https://ritense.tpondemand.com/RestUI/Board.aspx#page=userstory/37362&appConfig=eyJhY2lkIjoiOTNEM0VBODczQkE2RUIzQUJDQTJGNUUxMUM0MDBFN0EifQ== after I made it oops :P