### PR TITLE
Feature/story 37099

### DIFF
--- a/projects/valtimo/config/src/lib/models/config.ts
+++ b/projects/valtimo/config/src/lib/models/config.ts
@@ -102,7 +102,7 @@ export interface ValtimoConfig {
     showUserNameInTopBar?: boolean;
     experimentalDmnEditing?: boolean;
   };
-  visibleTaskListTabs?: Array<DefaultTab>;
+  visibleTaskListTabs?: Array<TaskListTab>;
   customTaskList?: CustomTaskList;
   customLeftSidebar?: CustomLeftSidebar;
   caseObjectTypes?: {
@@ -116,7 +116,7 @@ export enum UploadProvider {
   DOCUMENTEN_API,
 }
 
-export enum DefaultTab {
+export enum TaskListTab {
   MINE = 'mine',
   OPEN = 'open',
   ALL = 'all'

--- a/projects/valtimo/config/src/lib/models/config.ts
+++ b/projects/valtimo/config/src/lib/models/config.ts
@@ -42,6 +42,12 @@ export interface CustomDossierHeaderItem {
   customClass?: string;
 }
 
+export enum DefaultTab {
+  MINE = 'mine',
+  OPEN = 'open',
+  ALL = 'all'
+}
+
 export interface CustomTaskList {
   fields: Array<DefinitionColumn>;
   defaultSortedColumn?: SortState;
@@ -102,6 +108,7 @@ export interface ValtimoConfig {
     showUserNameInTopBar?: boolean;
     experimentalDmnEditing?: boolean;
   };
+  visibleTaskListTabs?: Array<DefaultTab>;
   customTaskList?: CustomTaskList;
   customLeftSidebar?: CustomLeftSidebar;
   caseObjectTypes?: {

--- a/projects/valtimo/config/src/lib/models/config.ts
+++ b/projects/valtimo/config/src/lib/models/config.ts
@@ -42,12 +42,6 @@ export interface CustomDossierHeaderItem {
   customClass?: string;
 }
 
-export enum DefaultTab {
-  MINE = 'mine',
-  OPEN = 'open',
-  ALL = 'all'
-}
-
 export interface CustomTaskList {
   fields: Array<DefinitionColumn>;
   defaultSortedColumn?: SortState;
@@ -120,4 +114,10 @@ export enum UploadProvider {
   S3,
   OPEN_ZAAK,
   DOCUMENTEN_API,
+}
+
+export enum DefaultTab {
+  MINE = 'mine',
+  OPEN = 'open',
+  ALL = 'all'
 }

--- a/projects/valtimo/task/src/lib/task-list/task-list.component.html
+++ b/projects/valtimo/task/src/lib/task-list/task-list.component.html
@@ -35,16 +35,16 @@
           <h5 class="list-header-description">{{ listDescription }}</h5>
         </div>
         <div tabs>
-          <ul ngbNav [destroyOnHide]="false" (navChange)="tabChange($event)" class="nav-tabs">
-            <li [ngbNavItem]="1" [title]="'task-list.mine.title' | translate">
-              <a ngbNavLink>{{ 'task-list.mine.title' | translate }}</a>
-            </li>
-            <li [ngbNavItem]="2" [title]="'task-list.open.title' | translate">
-              <a ngbNavLink>{{ 'task-list.open.title' | translate }}</a>
-            </li>
-            <li [ngbNavItem]="3" [title]="'task-list.all.title' | translate">
-              <a ngbNavLink>{{ 'task-list.all.title' | translate }}</a>
-            </li>
+          <ul *ngIf="visibleTabs == null; else configuredTabs" ngbNav [destroyOnHide]="false" (navChange)="tabChange($event)" class="nav-tabs">
+              <li ngbNavItem="mine" [title]="'task-list.mine.title' | translate">
+                <a ngbNavLink>{{ 'task-list.mine.title' | translate }}</a>
+              </li>
+              <li ngbNavItem="open" [title]="'task-list.open.title' | translate">
+                <a ngbNavLink>{{ 'task-list.open.title' | translate }}</a>
+              </li>
+              <li ngbNavItem="all" [title]="'task-list.all.title' | translate">
+                <a ngbNavLink>{{ 'task-list.all.title' | translate }}</a>
+              </li>
           </ul>
         </div>
       </valtimo-list>
@@ -56,3 +56,13 @@
     ></valtimo-task-detail-modal>
   </div>
 </div>
+
+
+<ng-template #configuredTabs>
+  <ul ngbNav [destroyOnHide]="false" (navChange)="tabChange($event)" class="nav-tabs">
+    <li *ngFor="let tab of visibleTabs;" [ngbNavItem]="tab"
+        [title]="'task-list.' + tab + '.title' | translate">
+      <a ngbNavLink>{{ 'task-list.' + tab + '.title' | translate }}</a>
+    </li>
+  </ul>
+</ng-template>

--- a/projects/valtimo/task/src/lib/task-list/task-list.component.html
+++ b/projects/valtimo/task/src/lib/task-list/task-list.component.html
@@ -35,7 +35,7 @@
           <h5 class="list-header-description">{{ listDescription }}</h5>
         </div>
         <div tabs>
-          <ul *ngIf="visibleTabs == null; else configuredTabs" ngbNav [destroyOnHide]="false" (navChange)="tabChange($event)" class="nav-tabs">
+          <ul *ngIf="visibleTabs === null; else configuredTabs" ngbNav [destroyOnHide]="false" (navChange)="tabChange($event)" class="nav-tabs">
               <li ngbNavItem="mine" [title]="'task-list.mine.title' | translate">
                 <a ngbNavLink>{{ 'task-list.mine.title' | translate }}</a>
               </li>

--- a/projects/valtimo/task/src/lib/task-list/task-list.component.ts
+++ b/projects/valtimo/task/src/lib/task-list/task-list.component.ts
@@ -23,7 +23,7 @@ import {NGXLogger} from 'ngx-logger';
 import {TaskDetailModalComponent} from '../task-detail-modal/task-detail-modal.component';
 import {TranslateService} from '@ngx-translate/core';
 import {combineLatest, Subscription} from 'rxjs';
-import {ConfigService, DefaultTab, SortState} from '@valtimo/config';
+import {ConfigService, SortState, TaskListTab} from '@valtimo/config';
 
 moment.locale(localStorage.getItem('langKey') || '');
 
@@ -40,7 +40,7 @@ export class TaskListComponent implements OnDestroy {
     open: new TaskList(),
     all: new TaskList(),
   };
-  public visibleTabs: Array<DefaultTab> | null = null;
+  public visibleTabs: Array<TaskListTab> | null = null;
   public currentTaskType = 'mine';
   public listTitle: string | null = null;
   public listDescription: string | null = null;

--- a/projects/valtimo/task/src/lib/task-list/task-list.component.ts
+++ b/projects/valtimo/task/src/lib/task-list/task-list.component.ts
@@ -23,7 +23,7 @@ import {NGXLogger} from 'ngx-logger';
 import {TaskDetailModalComponent} from '../task-detail-modal/task-detail-modal.component';
 import {TranslateService} from '@ngx-translate/core';
 import {combineLatest, Subscription} from 'rxjs';
-import {SortState} from '@valtimo/config';
+import {ConfigService, DefaultTab, SortState} from '@valtimo/config';
 
 moment.locale(localStorage.getItem('langKey') || '');
 
@@ -40,24 +40,30 @@ export class TaskListComponent implements OnDestroy {
     open: new TaskList(),
     all: new TaskList(),
   };
+  public visibleTabs: Array<DefaultTab> | null = null;
   public currentTaskType = 'mine';
   public listTitle: string | null = null;
   public listDescription: string | null = null;
   public sortState: SortState | null = null;
   private translationSubscription: Subscription;
 
-  public paginationClicked(page: number, type: string) {
-    this.tasks[type].page = page - 1;
-    this.getTasks(type);
-  }
-
   constructor(
     private taskService: TaskService,
     private router: Router,
     private logger: NGXLogger,
-    private translateService: TranslateService
+    private translateService: TranslateService,
+    private configService: ConfigService
   ) {
+    this.visibleTabs = this.configService.config?.visibleTaskListTabs || null;
+    if (this.visibleTabs != null) {
+      this.currentTaskType = this.visibleTabs[0];
+    }
     this.setDefaultSorting();
+  }
+
+  public paginationClicked(page: number, type: string) {
+    this.tasks[type].page = page - 1;
+    this.getTasks(type);
   }
 
   paginationSet() {
@@ -74,20 +80,7 @@ export class TaskListComponent implements OnDestroy {
 
   tabChange(tab) {
     this.clearPagination(this.currentTaskType);
-
-    switch (tab.nextId) {
-      case 1:
-        this.getTasks('mine');
-        break;
-      case 2:
-        this.getTasks('open');
-        break;
-      case 3:
-        this.getTasks('all');
-        break;
-      default:
-        this.logger.fatal('Unreachable case');
-    }
+    this.getTasks(tab.nextId);
   }
 
   showTask(task) {

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -18,11 +18,19 @@
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 import {NgxLoggerLevel} from 'ngx-logger';
-import {DefinitionColumn, IncludeFunction, ROLE_ADMIN, ROLE_DEVELOPER, ROLE_USER, UploadProvider, ValtimoConfig,} from '@valtimo/config';
+import {
+  DefinitionColumn,
+  IncludeFunction,
+  ROLE_ADMIN,
+  ROLE_DEVELOPER,
+  ROLE_USER,
+  TaskListTab,
+  UploadProvider,
+  ValtimoConfig,
+} from '@valtimo/config';
 import {authenticationKeycloak} from './auth/keycloak-config.dev';
 import {emailExtensionInitializer, openZaakExtensionInitializer} from '@valtimo/open-zaak';
 import {connectorLinkExtensionInitializer} from '@valtimo/connector-management';
-import {DefaultTab} from '../../projects/valtimo/config/src/lib/models';
 
 const defaultDefinitionColumns: Array<DefinitionColumn> = [
   {
@@ -166,7 +174,7 @@ export const environment: ValtimoConfig = {
       },
     ],
   },
-  visibleTaskListTabs: [DefaultTab.MINE, DefaultTab.OPEN, DefaultTab.ALL],
+  visibleTaskListTabs: [TaskListTab.MINE, TaskListTab.OPEN, TaskListTab.ALL],
   customTaskList: {
     fields: [
       {

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -18,18 +18,11 @@
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 import {NgxLoggerLevel} from 'ngx-logger';
-import {
-  DefinitionColumn,
-  IncludeFunction,
-  ROLE_ADMIN,
-  ROLE_DEVELOPER,
-  ROLE_USER,
-  UploadProvider,
-  ValtimoConfig,
-} from '@valtimo/config';
+import {DefinitionColumn, IncludeFunction, ROLE_ADMIN, ROLE_DEVELOPER, ROLE_USER, UploadProvider, ValtimoConfig,} from '@valtimo/config';
 import {authenticationKeycloak} from './auth/keycloak-config.dev';
 import {emailExtensionInitializer, openZaakExtensionInitializer} from '@valtimo/open-zaak';
 import {connectorLinkExtensionInitializer} from '@valtimo/connector-management';
+import {DefaultTab} from '../../projects/valtimo/config/src/lib/models';
 
 const defaultDefinitionColumns: Array<DefinitionColumn> = [
   {
@@ -173,6 +166,7 @@ export const environment: ValtimoConfig = {
       },
     ],
   },
+  visibleTaskListTabs: [DefaultTab.MINE, DefaultTab.OPEN, DefaultTab.ALL],
   customTaskList: {
     fields: [
       {


### PR DESCRIPTION
For an implementation we got the question to only show the tab 'All Tasks' in the Valtimo task list page. I added a new environment property just to set the visible of certain tabs. I tried to touch existing code as much as possible, but ended up changing one function to make it easier when switching tabs. Feel free to comment if you prefer it a different way.