### PR TITLE
add event to action callback

### DIFF
--- a/projects/valtimo/components/src/lib/components/list/list.component.html
+++ b/projects/valtimo/components/src/lib/components/list/list.component.html
@@ -103,7 +103,7 @@
                 class="action-icon"
                 style="cursor: pointer"
                 [ngClass]="action.iconClass"
-                (click)="action.callback(item)"
+                (click)="action.callback(item, $event)"
               ></i>
             </td>
           </tr>


### PR DESCRIPTION
DOCS: https://github.com/valtimo-platform/valtimo-documentation/pull/163

I have made a list of overdue cases for AFS and I have a click listener on the rows to navigate to that case.

I now want to add an action to "ignore" that case and hide it in the list.

However, both my action and my row listener are being fired, which means I navigate to the case, which I don't want to.

I need the `$event` param to call `$event.stopPropagation()` in the action callback