### PR TITLE
feat: fix query params on keycloak redirect case tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -182,7 +182,7 @@
     },
     "dist/valtimo/account": {
       "name": "@valtimo/account",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -196,7 +196,7 @@
     },
     "dist/valtimo/analyse": {
       "name": "@valtimo/analyse",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -209,7 +209,7 @@
     },
     "dist/valtimo/auth0": {
       "name": "@valtimo/auth0",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -224,7 +224,7 @@
     },
     "dist/valtimo/authority": {
       "name": "@valtimo/authority",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -237,7 +237,7 @@
     },
     "dist/valtimo/bootstrap": {
       "name": "@valtimo/bootstrap",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -250,7 +250,7 @@
     },
     "dist/valtimo/choice-field": {
       "name": "@valtimo/choice-field",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -263,7 +263,7 @@
     },
     "dist/valtimo/choicefield": {
       "name": "@valtimo/choicefield",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -276,7 +276,7 @@
     },
     "dist/valtimo/components": {
       "name": "@valtimo/components",
-      "version": "0.0.0-watch+1668524041448",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -303,7 +303,7 @@
     },
     "dist/valtimo/config": {
       "name": "@valtimo/config",
-      "version": "0.0.0-watch+1668524034363",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -316,7 +316,7 @@
     },
     "dist/valtimo/connector-management": {
       "name": "@valtimo/connector-management",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -330,7 +330,7 @@
     },
     "dist/valtimo/contact-moment": {
       "name": "@valtimo/contact-moment",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -343,7 +343,7 @@
     },
     "dist/valtimo/context": {
       "name": "@valtimo/context",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -356,7 +356,7 @@
     },
     "dist/valtimo/customer": {
       "name": "@valtimo/customer",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -369,7 +369,7 @@
     },
     "dist/valtimo/dashboard": {
       "name": "@valtimo/dashboard",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -387,7 +387,7 @@
     },
     "dist/valtimo/decision": {
       "name": "@valtimo/decision",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -402,7 +402,7 @@
     },
     "dist/valtimo/document": {
       "name": "@valtimo/document",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -415,7 +415,7 @@
     },
     "dist/valtimo/dossier": {
       "name": "@valtimo/dossier",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -433,7 +433,7 @@
     },
     "dist/valtimo/dossier-management": {
       "name": "@valtimo/dossier-management",
-      "version": "0.0.0-watch+1668525484063",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -446,7 +446,7 @@
     },
     "dist/valtimo/form-link": {
       "name": "@valtimo/form-link",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -459,7 +459,7 @@
     },
     "dist/valtimo/form-management": {
       "name": "@valtimo/form-management",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -472,7 +472,7 @@
     },
     "dist/valtimo/keycloak": {
       "name": "@valtimo/keycloak",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -487,7 +487,7 @@
     },
     "dist/valtimo/layout": {
       "name": "@valtimo/layout",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -547,7 +547,7 @@
     },
     "dist/valtimo/management": {
       "name": "@valtimo/management",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -566,7 +566,7 @@
     },
     "dist/valtimo/migration": {
       "name": "@valtimo/migration",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -579,7 +579,7 @@
     },
     "dist/valtimo/milestone": {
       "name": "@valtimo/milestone",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -593,7 +593,7 @@
     },
     "dist/valtimo/open-zaak": {
       "name": "@valtimo/open-zaak",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -606,7 +606,7 @@
     },
     "dist/valtimo/plugin": {
       "name": "@valtimo/plugin",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -620,7 +620,7 @@
     },
     "dist/valtimo/plugin-management": {
       "name": "@valtimo/plugin-management",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -634,7 +634,7 @@
     },
     "dist/valtimo/process": {
       "name": "@valtimo/process",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -652,7 +652,7 @@
     },
     "dist/valtimo/process-management": {
       "name": "@valtimo/process-management",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -667,7 +667,7 @@
     },
     "dist/valtimo/resource": {
       "name": "@valtimo/resource",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -680,7 +680,7 @@
     },
     "dist/valtimo/security": {
       "name": "@valtimo/security",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -694,7 +694,7 @@
     },
     "dist/valtimo/swagger": {
       "name": "@valtimo/swagger",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -708,7 +708,7 @@
     },
     "dist/valtimo/task": {
       "name": "@valtimo/task",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -723,7 +723,7 @@
     },
     "dist/valtimo/user-interface": {
       "name": "@valtimo/user-interface",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -752,7 +752,7 @@
     },
     "dist/valtimo/user-management": {
       "name": "@valtimo/user-management",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
@@ -766,7 +766,7 @@
     },
     "dist/valtimo/view-configurator": {
       "name": "@valtimo/view-configurator",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {

--- a/projects/valtimo/dossier/src/lib/models/tabs.model.ts
+++ b/projects/valtimo/dossier/src/lib/models/tabs.model.ts
@@ -93,7 +93,12 @@ export class TabLoaderImpl implements TabLoader<TabImpl> {
     const urlParts = currentUrl.split('/');
     urlParts.splice(urlParts.length - 1, 1, tab.name);
     const newUrl = urlParts.join('/');
-    this._location.replaceState(`${newUrl}${queryParams ? '?' + queryParams : ''}`);
+
+    if (currentUrl.includes(newUrl) && queryParams) {
+      this._router.navigateByUrl(`${newUrl}?${queryParams}`);
+    } else {
+      this._router.navigateByUrl(newUrl);
+    }
   }
 
   private setActive(tab: TabImpl): void {

--- a/projects/valtimo/dossier/src/lib/models/tabs.model.ts
+++ b/projects/valtimo/dossier/src/lib/models/tabs.model.ts
@@ -89,10 +89,11 @@ export class TabLoaderImpl implements TabLoader<TabImpl> {
 
   private replaceUrlState(tab: TabImpl): void {
     const currentUrl = this._router.url;
+    const queryParams = currentUrl.split('?')[1] || '';
     const urlParts = currentUrl.split('/');
     urlParts.splice(urlParts.length - 1, 1, tab.name);
     const newUrl = urlParts.join('/');
-    this._location.replaceState(newUrl);
+    this._location.replaceState(`${newUrl}${queryParams ? '?' + queryParams : ''}`);
   }
 
   private setActive(tab: TabImpl): void {


### PR DESCRIPTION
Functional: If I navigate directly to http://localhost:4200/dossiers/leningen/document/0d9dd2b8-0ee8-4bef-8799-108515b3ca7c/summary?test=test, the query params are retained. If I navigate to other tabs, the params are lost. If I navigate then back to summary tab, the params are also not there anymore.