### PR TITLE
bugfix: size of collection

### DIFF
--- a/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.html
+++ b/projects/valtimo/dossier/src/lib/dossier-list/dossier-list.component.html
@@ -117,7 +117,7 @@
               <h3 class="list-header-title">
                 {{ (schema$ | async)?.title }}
                 <sup class="ml-1 badge badge-pill badge-primary">{{
-                  documentItems?.length || 0
+                  pagination?.collectionSize || 0
                 }}</sup>
               </h3>
             </div>


### PR DESCRIPTION
bugfix/*-dg-dg

Fix: Fixes the bug where the total number of items on the page was shown instead of the total size of the collection.