### PR TITLE
Improvement to case and form definition upload

### DIFF
--- a/projects/valtimo/config/assets/core/de.json
+++ b/projects/valtimo/config/assets/core/de.json
@@ -494,11 +494,12 @@
     "jsonDocDef": "Die Case-Definition muss im JSON-Format sein",
     "formJsonDocDef": "Die Formular-Definition muss im JSON-Format sein",
     "error": {
-      "tooBig": "Die Detai ist zu groß",
+      "tooBig": "Die Datei ist zu groß",
       "wrongType": "Der Dokumenten-Typ wird nicht unterstützt",
       "generic": "Etwas ist schief gelaufen. Bitte erneut versuchen.",
       "invalidDocDef": "Die Case-Definition konnte nicht hochgeladen werden. Bitte erneut versuchen.",
-      "invalidFormDef": "Die Formular-Definition ist ungültig. Bitte erneut versuchen."
+      "invalidFormDef": "Die Formular-Definition ist ungültig. Bitte erneut versuchen.",
+      "invalidJson": "Es gibt ein Fehler in der Datei. Bitte überprüfen ob es einen gültigen JSON-Wert enthält."
     }
   },
   "fieldLabels": {

--- a/projects/valtimo/config/assets/core/en.json
+++ b/projects/valtimo/config/assets/core/en.json
@@ -498,7 +498,8 @@
       "wrongType": "The filetype of the file you tried to submit is not supported",
       "generic": "Something went wrong. Please try again.",
       "invalidDocDef": "The case definition could not be uploaded. Please try again.",
-      "invalidFormDef": "The form definition is not valid. Please try again."
+      "invalidFormDef": "The form definition is not valid. Please try again.",
+      "invalidJson": "The file contains an error. Please make sure it contains a valid JSON value."
     }
   },
   "fieldLabels": {

--- a/projects/valtimo/config/assets/core/nl.json
+++ b/projects/valtimo/config/assets/core/nl.json
@@ -498,7 +498,8 @@
       "wrongType": "Het bestandstype van het opgegeven bestand wordt niet ondersteund",
       "generic": "Er ging iets mis. Probeer het opnieuw.",
       "invalidDocDef": "Uw dossier-definitie kon niet geüpload worden. Probeer het opnieuw.",
-      "invalidFormDef": "Uw formulier-definitie is niet geldig. Probeer het opnieuw."
+      "invalidFormDef": "Uw formulier-definitie is niet geldig. Probeer het opnieuw.",
+      "invalidJson": "Het opgegeven bestand bevat een fout. Controleer of de inhoud een geldige JSON-waarde is."
     }
   },
   "fieldLabels": {

--- a/projects/valtimo/dossier-management/src/lib/dossier-management-upload/dossier-management-upload.component.html
+++ b/projects/valtimo/dossier-management/src/lib/dossier-management-upload/dossier-management-upload.component.html
@@ -26,10 +26,11 @@
       [disabled]="disabled$ | async"
       [subtitle]="'dropzone.jsonDocDef' | translate"
       [externalError$]="error$"
+      [maxFiles]="1"
     ></valtimo-dropzone>
   </div>
   <div footer>
-    <ng-container *ngIf="(jsonString$ | async) && (error$ | async) === ''; else pleaseSelect">
+    <ng-container *ngIf="(jsonString$ | async) && (error$ | async) === ''; else disabledUpload">
       <button [disabled]="disabled$ | async" class="btn btn-primary" (click)="uploadDefinition()">
         <i class="icon mdi mdi-upload mr-1"></i>
         {{ 'Upload' | translate }}
@@ -38,8 +39,9 @@
   </div>
 </valtimo-modal>
 
-<ng-template #pleaseSelect>
-  <button class="btn btn-primary" [disabled]="true">
-    {{ 'Select a document definition' | translate }}
+<ng-template #disabledUpload>
+  <button [disabled]="true" class="btn btn-primary" >
+    <i class="icon mdi mdi-upload mr-1"></i>
+    {{ 'Upload' | translate }}
   </button>
 </ng-template>

--- a/projects/valtimo/dossier-management/src/lib/dossier-management-upload/dossier-management-upload.component.ts
+++ b/projects/valtimo/dossier-management/src/lib/dossier-management-upload/dossier-management-upload.component.ts
@@ -136,6 +136,9 @@ export class DossierManagementUploadComponent implements AfterViewInit, OnDestro
           const result = reader.result.toString();
           if (this.stringIsValidJson(result)) {
             this.jsonString$.next(result);
+          } else {
+            this.clearJsonString();
+            this.error$.next(this.translateService.instant('dropzone.error.invalidJson'));
           }
         };
 

--- a/projects/valtimo/form-management/src/lib/form-management-upload/form-management-upload.component.html
+++ b/projects/valtimo/form-management/src/lib/form-management-upload/form-management-upload.component.html
@@ -26,10 +26,11 @@
       [disabled]="disabled$ | async"
       [subtitle]="'dropzone.formJsonDocDef' | translate"
       [externalError$]="error$"
+      [maxFiles]="1"
     ></valtimo-dropzone>
   </div>
   <div footer>
-    <ng-container *ngIf="(jsonString$ | async) && (error$ | async) === ''; else pleaseSelect">
+    <ng-container *ngIf="(jsonString$ | async) && (error$ | async) === ''; else disabledUpload">
       <button [disabled]="disabled$ | async" class="btn btn-primary" (click)="uploadDefinition()">
         {{ 'Upload' | translate }}
       </button>
@@ -37,8 +38,9 @@
   </div>
 </valtimo-modal>
 
-<ng-template #pleaseSelect>
-  <button class="btn btn-primary" [disabled]="true">
-    {{ 'Select a document definition' | translate }}
+<ng-template #disabledUpload>
+  <button [disabled]="true" class="btn btn-primary" >
+    <i class="icon mdi mdi-upload mr-1"></i>
+    {{ 'Upload' | translate }}
   </button>
 </ng-template>

--- a/projects/valtimo/form-management/src/lib/form-management-upload/form-management-upload.component.ts
+++ b/projects/valtimo/form-management/src/lib/form-management-upload/form-management-upload.component.ts
@@ -110,6 +110,9 @@ export class FormManagementUploadComponent implements AfterViewInit, OnDestroy {
           const result = reader.result.toString();
           if (this.stringIsValidJson(result)) {
             this.jsonString$.next(result);
+          } else {
+            this.clearJsonString();
+            this.error$.next(this.translateService.instant('dropzone.error.invalidJson'));
           }
         };
 


### PR DESCRIPTION
- Bugfix: "Upload" button was incorrectly enabled when uploading a correct file, but then replacing it with an incorrect file
- Added a user-friendly error message if the submitted .json file contains an incorrect JSON string
- Applied both changes to the case definition upload form and the form definition upload form