### PR TITLE
Feature/story 37634

### DIFF
--- a/projects/valtimo/dossier/src/lib/dossier-detail/dossier-detail.component.html
+++ b/projects/valtimo/dossier/src/lib/dossier-detail/dossier-detail.component.html
@@ -55,7 +55,9 @@
                     href="#"
                     (click)="startProcess(processDocumentDefinition)"
                   >
-                    {{ processDocumentDefinition.processName }}
+                    {{ (processDocumentDefinition?.id?.processDefinitionKey | translate) !== processDocumentDefinition?.id?.processDefinitionKey
+                    ? (processDocumentDefinition.id.processDefinitionKey | translate)
+                    : processDocumentDefinition.processName }}
                   </button>
                 </div>
               </div>

--- a/projects/valtimo/dossier/src/lib/dossier-supporting-process-start-modal/dossier-supporting-process-start-modal.component.html
+++ b/projects/valtimo/dossier/src/lib/dossier-supporting-process-start-modal/dossier-supporting-process-start-modal.component.html
@@ -17,7 +17,7 @@
 <valtimo-modal
   #supportingProcessStartModal
   elementId="supportingProcessStartModal"
-  [title]="modalTitle"
+  [title]="(processDefinitionKey | translate) !== processDefinitionKey ? (processDefinitionKey | translate) : processName"
 >
   <div body *ngIf="formDefinition">
     <valtimo-form-io

--- a/projects/valtimo/dossier/src/lib/dossier-supporting-process-start-modal/dossier-supporting-process-start-modal.component.ts
+++ b/projects/valtimo/dossier/src/lib/dossier-supporting-process-start-modal/dossier-supporting-process-start-modal.component.ts
@@ -115,10 +115,6 @@ export class DossierSupportingProcessStartModalComponent {
       );
   }
 
-  public get modalTitle() {
-    return `Start - ${this.processName}`;
-  }
-
   openModal(processDocumentDefinition: ProcessDocumentDefinition, documentId: string) {
     this.documentId = documentId;
     this.documentDefinitionName = processDocumentDefinition.id.documentDefinitionId.name;


### PR DESCRIPTION
Added the ability to translate the subprocess name in the menu under the dossier detail start button and in the subprocess task modal.

Acceptance criteria from the story in targetprocess.

- The process name in the 'supporting processes' drop-down is translated based on the process definition key
   - If no translation key is set, the process name is used (equal to the current situation)
- The title of the start-form modal is translated based on the process definition key
   - If no translation key is set, the process name is used (equal to the current situation)
- The 'Start - ' prefix has been removed from the start-form modal