### PR TITLE
feature/form-io-current-user

### DIFF
--- a/projects/valtimo/components/src/lib/components/form-io/form-io-current-user/form-io-current-user-edit-form.ts
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io-current-user/form-io-current-user-edit-form.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015-2020 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const formIoCurrentUserEditForm = () => ({
+  components: [
+    {
+      key: 'type',
+      type: 'hidden'
+    }, {
+      key: 'label',
+      type: 'textfield',
+      input: true,
+      label: 'Label',
+      placeholder: 'Label',
+      defaultValue: 'Valtimo Current User',
+      validate: {
+        required: true,
+      },
+    }, {
+      key: 'key',
+      type: 'textfield',
+      input: true,
+      label: 'Property Name',
+      placeholder: 'Property Name',
+      tooltip: 'The name of this field in the API endpoint.',
+      validate: {
+        required: true,
+      },
+    }, {
+      key: 'tableView',
+      type: 'checkbox',
+      label: 'Table View',
+      tooltip: 'If checked, this value will show up in the table view of the submissions list.'
+    }, {
+      key: 'hideLabel',
+      type: 'checkbox',
+      label: 'Hide Label',
+      tooltip: 'Hide the label of this component. This setting will display the label in the form builder, but hide the label when the form is rendered.'
+    }, {
+      key: 'hidden',
+      type: 'checkbox',
+      label: 'Hidden',
+      tooltip: 'A hidden field is still a part of the form JSON, but is hidden when viewing the form is rendererd.'
+    },
+  ],
+});

--- a/projects/valtimo/components/src/lib/components/form-io/form-io-current-user/form-io-current-user.component.ts
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io-current-user/form-io-current-user.component.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015-2020 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {FormioCustomComponent} from '@formio/angular';
+import {KeycloakService} from 'keycloak-angular';
+import {KeycloakProfile} from 'keycloak-js';
+
+@Component({
+  selector: 'valtimo-formio-current-user',
+  template: '{{ this.value?.firstName }} {{ this.value?.lastName }}<br />{{ this.value?.email }}',
+  styles: []
+})
+
+export class FormIoCurrentUserComponent implements FormioCustomComponent<any> {
+  @Input() value: any;
+  @Input() disabled: boolean;
+  @Output() valueChange = new EventEmitter<any>();
+
+  constructor(
+    private readonly keycloakService: KeycloakService,
+  ) {
+    this.keycloakService.loadUserProfile().then((profile:KeycloakProfile) => {
+      this.value = profile;
+      this.valueChange.emit();
+    });
+  }
+}

--- a/projects/valtimo/components/src/lib/components/form-io/form-io-current-user/form-io-current-user.formio.ts
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io-current-user/form-io-current-user.formio.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2020 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Injector} from '@angular/core';
+import {
+  FormioCustomComponentInfo,
+  registerCustomFormioComponent,
+} from '@formio/angular';
+import {formIoCurrentUserEditForm} from './form-io-current-user-edit-form';
+import {FormIoCurrentUserComponent} from './form-io-current-user.component';
+
+const COMPONENT_OPTIONS: FormioCustomComponentInfo = {
+  type: 'valtimo-current-user',
+  selector: 'valtimo-form-io-current-user',
+  title: 'Valtimo Current User',
+  group: 'basic',
+  icon: 'user',
+  editForm: formIoCurrentUserEditForm,
+  schema: {
+    label: 'Valtimo Current User',
+    tableView: true,
+  }
+};
+
+export function registerFormioCurrentUserComponent(injector: Injector) {
+  registerCustomFormioComponent(COMPONENT_OPTIONS, FormIoCurrentUserComponent, injector);
+}

--- a/projects/valtimo/components/src/lib/components/form-io/form-io.module.ts
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io.module.ts
@@ -30,6 +30,7 @@ import {ResourceModule} from '@valtimo/resource';
 import {RouterModule} from '@angular/router';
 import {DocumentenApiUploaderComponent} from './documenten-api-uploader/documenten-api-uploader.component';
 import {DocumentenApiMetadataModalModule} from '../documenten-api-metadata-modal/documenten-api-metadata-modal.module';
+import {FormIoCurrentUserComponent} from './form-io-current-user/form-io-current-user.component';
 
 @NgModule({
   imports: [
@@ -48,12 +49,14 @@ import {DocumentenApiMetadataModalModule} from '../documenten-api-metadata-modal
     FormioBuilderComponent,
     FormIoUploaderComponent,
     DocumentenApiUploaderComponent,
+    FormIoCurrentUserComponent
   ],
   exports: [
     FormioComponent,
     FormioBuilderComponent,
     FormIoUploaderComponent,
     DocumentenApiUploaderComponent,
+    FormIoCurrentUserComponent,
   ],
   providers: [FormIoDomService, {provide: FormioAppConfig, useValue: AppConfig}],
 })

--- a/projects/valtimo/components/src/public_api.ts
+++ b/projects/valtimo/components/src/public_api.ts
@@ -115,6 +115,9 @@ export * from './lib/components/form-io/form-io-uploader/form-io-uploader.formio
 export * from './lib/components/form-io/documenten-api-uploader/documenten-api-uploader.component';
 export * from './lib/components/form-io/documenten-api-uploader/documenten-api-uploader.formio';
 
+export * from './lib/components/form-io/form-io-current-user/form-io-current-user.component';
+export * from './lib/components/form-io/form-io-current-user/form-io-current-user.formio';
+
 export * from './lib/components/form-io/form-io-resource-selector/form-io-resource-selector.formio';
 
 export * from './lib/components/form-io/services/form-io-state.service';

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -32,6 +32,7 @@ import {
   registerDocumentenApiFormioUploadComponent,
   registerFormioFileSelectorComponent,
   registerFormioUploadComponent,
+  registerFormioCurrentUserComponent,
   UploaderModule,
   WidgetModule,
 } from '@valtimo/components';
@@ -213,6 +214,7 @@ export function tabsFactory() {
 })
 export class AppModule {
   constructor(injector: Injector) {
+    registerFormioCurrentUserComponent(injector);
     registerFormioUploadComponent(injector);
     registerFormioFileSelectorComponent(injector);
     registerDocumentenApiFormioUploadComponent(injector);


### PR DESCRIPTION
A custom form-io component that providing Valtimo user profile as form input.

- Added form-io current user component, and return keycloak profile as value
- Added custom component register info
- Added custom component edit form
- Assigned to form-io module
- Exported custom component
- Imported registerFormioCurrentUserComponent and added to AppModule constructor