### PR TITLE
Bugfix: fix form-flow back button prompt close button

### DIFF
--- a/projects/valtimo/task/src/lib/task-detail-modal/task-detail-modal.component.ts
+++ b/projects/valtimo/task/src/lib/task-detail-modal/task-detail-modal.component.ts
@@ -210,6 +210,9 @@ export class TaskDetailModalComponent {
           errors => this.form.showErrors(errors)
         );
       },
+      closeCallBackFunction: () => {
+        this.openTaskDetails(this.task);
+      },
     });
   }
 

--- a/projects/valtimo/user-interface/src/lib/services/prompt.service.ts
+++ b/projects/valtimo/user-interface/src/lib/services/prompt.service.ts
@@ -41,6 +41,7 @@ export class PromptService {
   private readonly _closeButtonVisible$ = new BehaviorSubject<boolean>(false);
   private readonly _cancelCallbackFunction$ = new BehaviorSubject<() => void>(() => {});
   private readonly _confirmCallbackFunction$ = new BehaviorSubject<() => void>(() => {});
+  private readonly _closeCallbackFunction$ = new BehaviorSubject<() => void>(() => {});
 
   get promptVisible$() {
     return this._promptVisible$.asObservable();
@@ -117,6 +118,7 @@ export class PromptService {
     closeButtonVisible?: boolean;
     cancelCallbackFunction?: () => void;
     confirmCallBackFunction?: () => void;
+    closeCallBackFunction?: () => void;
   }): void {
     if (promptParameters.identifier) this._identifier$.next(promptParameters.identifier);
     this._headerText$.next(promptParameters.headerText);
@@ -139,6 +141,8 @@ export class PromptService {
       this._cancelCallbackFunction$.next(promptParameters.cancelCallbackFunction);
     if (promptParameters.confirmCallBackFunction)
       this._confirmCallbackFunction$.next(promptParameters.confirmCallBackFunction);
+    if (promptParameters.closeCallBackFunction)
+      this._closeCallbackFunction$.next(promptParameters.closeCallBackFunction);
 
     this._promptVisible$.next(true);
     this._appearing$.next(true);
@@ -178,11 +182,11 @@ export class PromptService {
   }
 
   close(): void {
-    this._closeButtonVisible$
+    combineLatest([this._closeButtonVisible$, this._closeCallbackFunction$])
       .pipe(take(1))
-      .subscribe((closeButtonVisible) => {
+      .subscribe(([closeButtonVisible, cancelCallback]) => {
         if (closeButtonVisible) {
-          this.closePrompt();
+          this.closePrompt(cancelCallback);
         }
       });
   }
@@ -227,5 +231,6 @@ export class PromptService {
     this._closeOnConfirm$.next(false);
     this._cancelCallbackFunction$.next(() => {});
     this._confirmCallbackFunction$.next(() => {});
+    this._closeCallbackFunction$.next(() => {});
   }
 }


### PR DESCRIPTION
Fixes bug: 
When navigating away from the form in a form flow, and the prompt shows up, and then clicking the 'x' to close the prompt. It is no longer possible to submit the form