### PR TITLE
The names in the dropdown list are sorted on lastname, but if a user …

### DIFF
--- a/projects/valtimo/dossier/src/lib/dossier-assign-user/dossier-assign-user.component.ts
+++ b/projects/valtimo/dossier/src/lib/dossier-assign-user/dossier-assign-user.component.ts
@@ -114,16 +114,20 @@ export class DossierAssignUserComponent implements OnInit, OnChanges, OnDestroy 
       )
       .subscribe();
   }
-
+  
   mapUsersForDropdown(users: User[]): DropdownItem[] {
     return (
       users &&
       users
-        .sort((a, b) => a.lastName.localeCompare(b.lastName))
+        .sort((a, b) => {
+          if (a.lastName && b.lastName) {
+            return a.lastName.localeCompare(b.lastName)
+          }
+        })
         .map(user => ({text: `${user.firstName} ${user.lastName}`, id: user.id}))
     );
   }
-
+  
   private clear(): void {
     this.assignedIdOnServer$.next(null);
     this.userIdToAssign = null;


### PR DESCRIPTION
The names in the dropdown list are sorted on lastname, but if a user doesn't have a last assigned in Keycloak it will actually break the ability to select a user. A check has been added to prevent it from breaking.