### PR TITLE
TG-46030 - Ability to override the feedback menu item in the right sidebar for a mailTo item where the content of the email is set with a property in the translation file

### DIFF
--- a/projects/valtimo/components/src/lib/components/right-sidebar/right-sidebar.component.html
+++ b/projects/valtimo/components/src/lib/components/right-sidebar/right-sidebar.component.html
@@ -128,7 +128,7 @@
         </ibm-list-column>
       </ibm-list-row>
       <ibm-list-row>
-        <ibm-list-column>
+        <ibm-list-column *ngIf="!overrideFeedbackMenuItemToMailTo; else feedbackMailTo">
           <a href="https://www.valtimo.nl/feedback" target="_blank" ibmLink>{{
             'account.links.feedback' | translate
           }}</a>
@@ -157,8 +157,7 @@
       </ibm-list-row>
       <ibm-list-row *ngIf="showPlantATreeButton">
         <ibm-list-column>
-          <a
-            class="text-success"
+          <a class="text-success"
             href="mailto:valtimo@ritense.com?subject=Plant een boom voor Valtimo&body=Hallo Valtimo gebruiker,%0D%0DMet het versturen van deze e-mail gaan we gelijk aan de slag om een boom te planten. Hiermee compenseren we voor een deel de CO2 uitstoot van je Valtimo gebruik.%0D%0DMet Groene Groet,%0D%0DHet Valtimo team%0D%0D*Deze bomenplantactie kan 1 keer ingezet worden door elke geregistreerde Valtimo gebruiker.%0D%0D** Ritense plant ook jaarlijks bomen voor alle Valtimo installaties die in gebruik zijn."
             target="_blank"
             ibmLink
@@ -251,4 +250,17 @@
       </ibm-list-row>
     </ibm-structured-list>
   </ng-container>
+</ng-template>
+
+<ng-template #feedbackMailTo>
+  <ibm-list-column>
+    <a [href]="'mailto:' + overrideFeedbackMenuItemToMailTo.email +
+        '?subject=' + (overrideFeedbackMenuItemToMailTo.subjectTranslationKey | translate) +
+        '&body=' + (overrideFeedbackMenuItemToMailTo.bodyTranslationKey | translate)"
+       target="_blank"
+       ibmLink
+    >
+      {{ 'account.links.feedback' | translate }}
+    </a>
+  </ibm-list-column>
 </ng-template>

--- a/projects/valtimo/components/src/lib/components/right-sidebar/right-sidebar.component.ts
+++ b/projects/valtimo/components/src/lib/components/right-sidebar/right-sidebar.component.ts
@@ -104,6 +104,7 @@ export class RightSidebarComponent implements OnInit, OnDestroy {
 
   readonly userContexts$ = this.contextService.getUserContexts();
   readonly activeContext$ = this.contextService.getUserContextActive();
+
   private formSubscription!: Subscription;
 
   constructor(
@@ -128,7 +129,7 @@ export class RightSidebarComponent implements OnInit, OnDestroy {
     this.openFormSubscription();
     this.showPlantATreeButton = this.configService.config.featureToggles?.showPlantATreeButton;
     this.resetUrl = this.configService.config.changePasswordUrl?.endpointUri;
-    this.overrideFeedbackMenuItemToMailTo = this.configService.config.featureToggles?.overrideFeedbackMenuItemToMailTo;
+    this.overrideFeedbackMenuItemToMailTo = this.configService.config?.overrideFeedbackMenuItemToMailTo;
   }
 
   ngOnDestroy(): void {

--- a/projects/valtimo/components/src/lib/components/right-sidebar/right-sidebar.component.ts
+++ b/projects/valtimo/components/src/lib/components/right-sidebar/right-sidebar.component.ts
@@ -27,7 +27,7 @@ import {FormBuilder, FormControl, FormGroup} from '@angular/forms';
 import {TranslateService} from '@ngx-translate/core';
 import {ContextService} from '@valtimo/context';
 import {ValtimoVersion} from '../../models';
-import {EmailNotificationSettings, UserIdentity, ConfigService} from '@valtimo/config';
+import {EmailNotificationSettings, UserIdentity, ConfigService, FeedbackMailTo} from '@valtimo/config';
 import {UserProviderService} from '@valtimo/security';
 import {NGXLogger} from 'ngx-logger';
 import {BehaviorSubject, combineLatest, Observable, Subscription, take} from 'rxjs';
@@ -76,6 +76,7 @@ export class RightSidebarComponent implements OnInit, OnDestroy {
     emailNotificationOnSaturday: new FormControl(false),
     emailNotificationOnSunday: new FormControl(false),
   });
+  public overrideFeedbackMenuItemToMailTo: FeedbackMailTo;
   readonly panelExpanded$ = this.shellService.panelExpanded$;
 
   readonly selectedLanguage$ = new BehaviorSubject<string>('');
@@ -103,7 +104,6 @@ export class RightSidebarComponent implements OnInit, OnDestroy {
 
   readonly userContexts$ = this.contextService.getUserContexts();
   readonly activeContext$ = this.contextService.getUserContextActive();
-
   private formSubscription!: Subscription;
 
   constructor(
@@ -115,9 +115,7 @@ export class RightSidebarComponent implements OnInit, OnDestroy {
     private readonly http: HttpClient,
     private readonly logger: NGXLogger,
     private readonly shellService: ShellService,
-
     private readonly elementRef: ElementRef,
-
     private readonly configService: ConfigService
   ) {}
 
@@ -130,6 +128,7 @@ export class RightSidebarComponent implements OnInit, OnDestroy {
     this.openFormSubscription();
     this.showPlantATreeButton = this.configService.config.featureToggles?.showPlantATreeButton;
     this.resetUrl = this.configService.config.changePasswordUrl?.endpointUri;
+    this.overrideFeedbackMenuItemToMailTo = this.configService.config.featureToggles?.overrideFeedbackMenuItemToMailTo;
   }
 
   ngOnDestroy(): void {

--- a/projects/valtimo/config/src/lib/models/config.ts
+++ b/projects/valtimo/config/src/lib/models/config.ts
@@ -118,7 +118,6 @@ export interface ValtimoConfig {
     caseListColumn?: boolean;
     enableObjectManagement?: boolean;
     largeLogoMargin?: boolean;
-    overrideFeedbackMenuItemToMailTo?: FeedbackMailTo;
   };
   visibleTaskListTabs?: Array<TaskListTab>;
   visibleDossierListTabs?: Array<DossierListTab>;
@@ -127,6 +126,7 @@ export interface ValtimoConfig {
   caseObjectTypes?: {
     [definitionNameId: string]: Array<string>;
   };
+  overrideFeedbackMenuItemToMailTo?: FeedbackMailTo;
 }
 
 export interface FeedbackMailTo {

--- a/projects/valtimo/config/src/lib/models/config.ts
+++ b/projects/valtimo/config/src/lib/models/config.ts
@@ -118,6 +118,7 @@ export interface ValtimoConfig {
     caseListColumn?: boolean;
     enableObjectManagement?: boolean;
     largeLogoMargin?: boolean;
+    overrideFeedbackMenuItemToMailTo?: FeedbackMailTo;
   };
   visibleTaskListTabs?: Array<TaskListTab>;
   visibleDossierListTabs?: Array<DossierListTab>;
@@ -126,6 +127,12 @@ export interface ValtimoConfig {
   caseObjectTypes?: {
     [definitionNameId: string]: Array<string>;
   };
+}
+
+export interface FeedbackMailTo {
+  email?: string,
+  subjectTranslationKey: string,
+  bodyTranslationKey: string
 }
 
 export enum UploadProvider {


### PR DESCRIPTION
For one of our projects we would like the ability to change the behaviour of the Feedback menu item in the right sidebar to a mailTo trigger. Since it should be possible to setup the email in multiple languages I decided to created a environment property to override the current item (could also become a extra menu item if we don't want to override the current feedback). The subject and body are being filled by a translation property.

The story https://ritense.tpondemand.com/entity/46030-fe-add-feedback-mailto-option-with