### PR TITLE
Changed url of back button.

### DIFF
--- a/projects/valtimo/form-management/src/lib/form-management-create/form-management-create.component.html
+++ b/projects/valtimo/form-management/src/lib/form-management-create/form-management-create.component.html
@@ -52,7 +52,7 @@
             </div>
             <div class="row pt-3 mt-1">
               <div class="col-12 col-sm-6 text-left">
-                <a [routerLink]="'/forms'" class="btn btn-space btn-default">{{
+                <a [routerLink]="'/form-management'" class="btn btn-space btn-default">{{
                   'formManagement.back' | translate
                 }}</a>
               </div>


### PR DESCRIPTION
TP 51776: clicking 'back' button on new-form-definition page redirected user to the dashboard.

Release note PR: https://github.com/valtimo-platform/valtimo-documentation/pull/270