### PR TITLE
Form definition uuid value is replaced by the actual string value

### DIFF
--- a/projects/valtimo/object-management/src/lib/components/object-management-modal/object-management-modal.component.ts
+++ b/projects/valtimo/object-management/src/lib/components/object-management-modal/object-management-modal.component.ts
@@ -56,7 +56,7 @@ export class ObjectManagementModalComponent implements AfterViewInit, OnDestroy 
     this.formManagementService.queryFormDefinitions().pipe(
       map(results =>
         results?.body?.content.map(configuration => ({
-          id: configuration.id,
+          id: configuration.name,
           text: configuration.name,
         }))
       )
@@ -173,8 +173,8 @@ export class ObjectManagementModalComponent implements AfterViewInit, OnDestroy 
       !!(data.title &&
         data.objectenApiPluginConfigurationId &&
         data.objecttypenApiPluginConfigurationId &&
-        data.objecttypeId,
-      data.objecttypeVersion)
+        data.objecttypeId &&
+        data.objecttypeVersion)
     );
   }
 


### PR DESCRIPTION
When editing a object in the object-management it's currently saving the uuid instead of the name which breaks the forms in the object menu.