### PR TITLE
fix: process definition name not showing

### DIFF
--- a/projects/valtimo/process-management/src/lib/process-management-builder/process-management-builder.component.html
+++ b/projects/valtimo/process-management/src/lib/process-management-builder/process-management-builder.component.html
@@ -50,7 +50,7 @@
       >
         <div class="col-md-4" *ngIf="processDefinitionVersions.length > 0">
           <h2 class="process-title">
-            {{ processDefinitionVersions[0].name }}
+            {{ processDefinitionVersions[processDefinitionVersions.length - 1].name }}
           </h2>
           <span class="badge badge-pill badge-info mr-1" *ngIf="isReadOnlyProcess$ | async">
             {{ 'processManagement.readOnly' | translate }}


### PR DESCRIPTION
Instead of looking at the first element of the list of process versions, we look at the latest version now.