### PR TITLE
Update redirect function to support custom columns as well

### DIFF
--- a/projects/valtimo/object/src/lib/components/object-list/object-list.component.ts
+++ b/projects/valtimo/object/src/lib/components/object-list/object-list.component.ts
@@ -133,7 +133,7 @@ export class ObjectListComponent {
       });
     }),
     map(res => res.content.map(record => record?.items?.reduce(
-      (obj, item) => Object.assign(obj, { [item.key]: item.value }), {})
+      (obj, item) => Object.assign(obj, {objectId: record.id}, {[item.key]: item.value }), {})
     )),
     tap(() => this.loading$.next(false))
   );
@@ -179,6 +179,7 @@ export class ObjectListComponent {
     map(([columns]) => {
       if (columns?.length > 0) {
         this.columnType$.next(ColumnType.CUSTOM);
+
         return [
           ...columns
             .map(column => {
@@ -256,7 +257,7 @@ export class ObjectListComponent {
   }
 
   redirectToDetails(record): void {
-    const objectId = record.objectUrl.split('/').pop();
+    const objectId = record.objectUrl ? record.objectUrl.split('/').pop() : record.objectId;
     this.objectManagementId$.pipe(take(1)).subscribe(configurationId => {
       this.router.navigate([`/objects/${configurationId}/${objectId}`]);
     });


### PR DESCRIPTION
The redirect function was only supporting the default columns (which includes a url) and now it also adds the id when using custom columns.