### PR TITLE
TG-56479 - Only trigger the stop propagation if the clicked target is a checkbox (reason why this was added in the first place)

### DIFF
--- a/projects/valtimo/user-interface/src/lib/components/modal/modal.component.html
+++ b/projects/valtimo/user-interface/src/lib/components/modal/modal.component.html
@@ -46,7 +46,7 @@
     class="v-modal"
     (mouseenter)="modalMouseEnter()"
     (mouseleave)="modalMouseLeave()"
-    (click)="stopPropagation($event)"
+    (click)="stopPropagationBasedOnClickedTarget($event)"
     [style.max-width.px]="maxWidthPx"
   >
     <ng-container

--- a/projects/valtimo/user-interface/src/lib/components/modal/modal.component.ts
+++ b/projects/valtimo/user-interface/src/lib/components/modal/modal.component.ts
@@ -51,8 +51,11 @@ export class ModalComponent implements OnInit {
     this.modalService.closeModal();
   }
 
-  stopPropagation(event: Event): void {
-    event.stopPropagation();
+  stopPropagationBasedOnClickedTarget(event: Event): void {
+    const target = event.target as HTMLElement;
+    if (target.tagName === 'INPUT' && (target as HTMLInputElement).type === 'checkbox') {
+      event.stopPropagation();
+    }
   }
 
   modalMouseEnter(): void {


### PR DESCRIPTION
For the object-management a new input (checkbox) was introduced which was not working without triggering the stopPropagation. Without knowing this actually breaks existing functionality in the modal and this has now fixed by adding a specific target.