### PR TITLE
Enabled the option to tranlate formio forms with minimal translations

### DIFF
--- a/projects/valtimo/components/src/lib/components/form-io/form-io-builder.component.html
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io-builder.component.html
@@ -15,6 +15,11 @@
   -->
 
 <div>
-  <form-builder #formBuilder [form]="form" [rebuild]="triggerRebuild" [options]="formioOptions$ | async"
-                (change)="onChange($event)"></form-builder>
+  <form-builder
+    #formBuilder
+    [form]="form"
+    [rebuild]="triggerRebuild"
+    [options]="formioOptions$ | async"
+    (change)="onChange($event)"
+  ></form-builder>
 </div>

--- a/projects/valtimo/components/src/lib/components/form-io/form-io-builder.component.html
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io-builder.component.html
@@ -15,5 +15,6 @@
   -->
 
 <div>
-  <form-builder [form]="form" [options]="formioOptions$ | async" (change)="onChange($event)"></form-builder>
+  <form-builder #formBuilder [form]="form" [rebuild]="triggerRebuild" [options]="formioOptions$ | async"
+                (change)="onChange($event)"></form-builder>
 </div>

--- a/projects/valtimo/components/src/lib/components/form-io/form-io-builder.component.html
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io-builder.component.html
@@ -16,7 +16,6 @@
 
 <div>
   <form-builder
-    #formBuilder
     [form]="form"
     [rebuild]="triggerRebuild"
     [options]="formioOptions$ | async"

--- a/projects/valtimo/components/src/lib/components/form-io/form-io-builder.component.html
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io-builder.component.html
@@ -15,5 +15,5 @@
   -->
 
 <div>
-  <form-builder [form]="form" (change)="onChange($event)"></form-builder>
+  <form-builder [form]="form" [options]="formioOptions$ | async" (change)="onChange($event)"></form-builder>
 </div>

--- a/projects/valtimo/components/src/lib/components/form-io/form-io-builder.component.ts
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io-builder.component.ts
@@ -16,6 +16,9 @@
 
 import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
 import {Components} from '@formio/angular';
+import {map} from 'rxjs/operators';
+import {Observable} from 'rxjs';
+import {TranslateService} from '@ngx-translate/core';
 
 @Component({
   selector: 'valtimo-form-io-builder',
@@ -27,7 +30,23 @@ export class FormioBuilderComponent implements OnInit {
   // eslint-disable-next-line @angular-eslint/no-output-native
   @Output() change: EventEmitter<any> = new EventEmitter();
 
-  constructor() {}
+  readonly currentLanguage$ = this.translateService
+    .stream('key')
+    .pipe(map(() => this.translateService.currentLang));
+
+  readonly formioOptions$: Observable<{language: string, i18n: any }> = this.currentLanguage$.pipe(
+    map(language =>  {
+      const formioTranslations = this.translateService.instant('formioTranslations');
+      return typeof formioTranslations === 'object' ? {
+        language,
+        i18n: {
+          [language]: formioTranslations
+        }
+      } : null;
+    })
+  )
+
+  constructor(private translateService: TranslateService) {}
 
   ngOnInit() {
     const originalEditForm = Components.baseEditForm;

--- a/projects/valtimo/components/src/lib/components/form-io/form-io-builder.component.ts
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io-builder.component.ts
@@ -30,26 +30,29 @@ export class FormioBuilderComponent implements OnInit {
   @Input() form: any;
   // eslint-disable-next-line @angular-eslint/no-output-native
   @Output() change: EventEmitter<any> = new EventEmitter();
-  public triggerRebuild: EventEmitter<FormioOptions> = new EventEmitter()
+  public triggerRebuild: EventEmitter<FormioOptions> = new EventEmitter();
 
   readonly currentLanguage$ = this.translateService
     .stream('key')
     .pipe(map(() => this.translateService.currentLang));
 
   readonly formioOptions$: Observable<FormioOptions> = this.currentLanguage$.pipe(
-    map(language =>  {
+    map(language => {
       const formioTranslations = this.translateService.instant('formioTranslations');
-      const options = typeof formioTranslations === 'object' ? {
-        language,
-        i18n: {
-          [language]: formioTranslations
-        }
-      } : null;
+      const options =
+        typeof formioTranslations === 'object'
+          ? {
+              language,
+              i18n: {
+                [language]: formioTranslations,
+              },
+            }
+          : null;
 
       this.triggerRebuild.emit(options);
       return options;
     })
-  )
+  );
 
   constructor(private translateService: TranslateService) {}
 

--- a/projects/valtimo/components/src/lib/components/form-io/form-io-builder.component.ts
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io-builder.component.ts
@@ -30,6 +30,7 @@ export class FormioBuilderComponent implements OnInit {
   @Input() form: any;
   // eslint-disable-next-line @angular-eslint/no-output-native
   @Output() change: EventEmitter<any> = new EventEmitter();
+  public triggerRebuild: EventEmitter<FormioOptions> = new EventEmitter()
 
   readonly currentLanguage$ = this.translateService
     .stream('key')
@@ -38,12 +39,15 @@ export class FormioBuilderComponent implements OnInit {
   readonly formioOptions$: Observable<FormioOptions> = this.currentLanguage$.pipe(
     map(language =>  {
       const formioTranslations = this.translateService.instant('formioTranslations');
-      return typeof formioTranslations === 'object' ? {
+      const options = typeof formioTranslations === 'object' ? {
         language,
         i18n: {
           [language]: formioTranslations
         }
       } : null;
+
+      this.triggerRebuild.emit(options);
+      return options;
     })
   )
 

--- a/projects/valtimo/components/src/lib/components/form-io/form-io-builder.component.ts
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io-builder.component.ts
@@ -19,6 +19,7 @@ import {Components} from '@formio/angular';
 import {map} from 'rxjs/operators';
 import {Observable} from 'rxjs';
 import {TranslateService} from '@ngx-translate/core';
+import {FormioOptions} from '@formio/angular/formio.common';
 
 @Component({
   selector: 'valtimo-form-io-builder',
@@ -34,7 +35,7 @@ export class FormioBuilderComponent implements OnInit {
     .stream('key')
     .pipe(map(() => this.translateService.currentLang));
 
-  readonly formioOptions$: Observable<{language: string, i18n: any }> = this.currentLanguage$.pipe(
+  readonly formioOptions$: Observable<FormioOptions> = this.currentLanguage$.pipe(
     map(language =>  {
       const formioTranslations = this.translateService.instant('formioTranslations');
       return typeof formioTranslations === 'object' ? {

--- a/projects/valtimo/components/src/lib/components/form-io/form-io.component.html
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io.component.html
@@ -23,13 +23,16 @@
     </ol>
   </div>
   <formio
-    *ngIf="currentLanguage$ | async as currentLanguage"
+    *ngIf="{
+      currentLanguage: currentLanguage$ | async,
+      formioOptions: formioOptions$ | async
+    } as obs"
     [submission]="submission"
     [form]="formDefinition"
     [refresh]="refreshForm"
-    [options]="options"
+    [options]="obs.formioOptions || options"
     [readOnly]="readOnly"
-    [language]="currentLanguage"
+    [language]="obs.currentLanguage"
     (submit)="onSubmit($event)"
     (ready)="formReady($event)"
     (change)="onChange($event)"

--- a/projects/valtimo/components/src/lib/components/form-io/form-io.component.ts
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io.component.ts
@@ -64,17 +64,19 @@ export class FormioComponent implements OnInit, OnChanges, OnDestroy {
     .pipe(map(() => this.translateService.currentLang));
 
   readonly formioOptions$: Observable<ValtimoFormioOptions> = this.currentLanguage$.pipe(
-    map(language =>  {
+    map(language => {
       const formioTranslations = this.translateService.instant('formioTranslations');
-      return typeof formioTranslations === 'object' ? {
-        ...this.options,
-        language,
-        i18n: {
-          [language]: formioTranslations
-        }
-      } : this.options;
+      return typeof formioTranslations === 'object'
+        ? {
+            ...this.options,
+            language,
+            i18n: {
+              [language]: formioTranslations,
+            },
+          }
+        : this.options;
     })
-  )
+  );
 
   constructor(
     private userProviderService: UserProviderService,

--- a/projects/valtimo/components/src/lib/components/form-io/form-io.component.ts
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io.component.ts
@@ -32,7 +32,7 @@ import {FormioRefreshValue} from '@formio/angular/formio.common';
 import jwt_decode from 'jwt-decode';
 import {NGXLogger} from 'ngx-logger';
 import {from, Observable, Subject, Subscription, timer} from 'rxjs';
-import {map, switchMap, take} from 'rxjs/operators';
+import {distinctUntilChanged, map, switchMap, take} from 'rxjs/operators';
 import {FormIoStateService} from './services/form-io-state.service';
 import {ActivatedRoute} from '@angular/router';
 import {TranslateService} from '@ngx-translate/core';
@@ -59,9 +59,10 @@ export class FormioComponent implements OnInit, OnChanges, OnDestroy {
   private tokenRefreshTimerSubscription: Subscription;
   private formRefreshSubscription: Subscription;
 
-  readonly currentLanguage$ = this.translateService
-    .stream('key')
-    .pipe(map(() => this.translateService.currentLang));
+  readonly currentLanguage$ = this.translateService.stream('key').pipe(
+    map(() => this.translateService.currentLang),
+    distinctUntilChanged()
+  );
 
   readonly formioOptions$: Observable<ValtimoFormioOptions> = this.currentLanguage$.pipe(
     map(language => {
@@ -71,7 +72,7 @@ export class FormioComponent implements OnInit, OnChanges, OnDestroy {
             ...this.options,
             language,
             i18n: {
-              [language]: formioTranslations,
+              [language]: this.stateService.flattenTranslationsObject(formioTranslations),
             },
           }
         : this.options;

--- a/projects/valtimo/components/src/lib/components/form-io/form-io.component.ts
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io.component.ts
@@ -31,7 +31,7 @@ import {Formio, FormioComponent as FormIoSourceComponent, FormioForm} from '@for
 import {FormioRefreshValue} from '@formio/angular/formio.common';
 import jwt_decode from 'jwt-decode';
 import {NGXLogger} from 'ngx-logger';
-import {from, Subject, Subscription, timer} from 'rxjs';
+import {from, Observable, Subject, Subscription, timer} from 'rxjs';
 import {map, switchMap, take} from 'rxjs/operators';
 import {FormIoStateService} from './services/form-io-state.service';
 import {ActivatedRoute} from '@angular/router';
@@ -62,6 +62,19 @@ export class FormioComponent implements OnInit, OnChanges, OnDestroy {
   readonly currentLanguage$ = this.translateService
     .stream('key')
     .pipe(map(() => this.translateService.currentLang));
+
+  readonly formioOptions$: Observable<ValtimoFormioOptions> = this.currentLanguage$.pipe(
+    map(language =>  {
+      const formioTranslations = this.translateService.instant('formioTranslations');
+      return typeof formioTranslations === 'object' ? {
+        ...this.options,
+        language,
+        i18n: {
+          [language]: formioTranslations
+        }
+      } : this.options;
+    })
+  )
 
   constructor(
     private userProviderService: UserProviderService,

--- a/projects/valtimo/components/src/lib/components/form-io/services/form-io-state.service.ts
+++ b/projects/valtimo/components/src/lib/components/form-io/services/form-io-state.service.ts
@@ -51,14 +51,25 @@ export class FormIoStateService {
     this._currentForm$.next(form);
   }
 
-  flattenTranslationsObject(translations, flattened = {}, prefix = '') {
-    for (const key in translations) {
-      if (typeof translations[key] === 'object' && translations[key] !== null) {
-        this.flattenTranslationsObject(translations[key], flattened, prefix + key + '.');
-      } else {
-        flattened[prefix + key] = translations[key];
+  flattenTranslationsObject(translations) {
+    const stack = [{ prefix: '', value: translations }];
+    const flattened = {};
+
+    while (stack.length > 0) {
+      const { prefix, value } = stack.pop();
+
+      for (const key in value) {
+        const currentValue = value[key];
+        const currentPrefix = prefix + key + '.';
+
+        if (typeof currentValue === 'object' && currentValue !== null) {
+          stack.push({ prefix: currentPrefix, value: currentValue });
+        } else {
+          flattened[currentPrefix.slice(0, -1)] = currentValue;
+        }
       }
     }
+
     return flattened;
   }
 }

--- a/projects/valtimo/components/src/lib/components/form-io/services/form-io-state.service.ts
+++ b/projects/valtimo/components/src/lib/components/form-io/services/form-io-state.service.ts
@@ -58,8 +58,7 @@ export class FormIoStateService {
     while (stack.length > 0) {
       const { prefix, value } = stack.pop();
 
-      for (const key in value) {
-        const currentValue = value[key];
+      Object.entries(value).forEach(([key, currentValue]) => {
         const currentPrefix = prefix + key + '.';
 
         if (typeof currentValue === 'object' && currentValue !== null) {
@@ -67,9 +66,9 @@ export class FormIoStateService {
         } else {
           flattened[currentPrefix.slice(0, -1)] = currentValue;
         }
-      }
+      });
     }
 
     return flattened;
-  }
+  };
 }

--- a/projects/valtimo/components/src/lib/components/form-io/services/form-io-state.service.ts
+++ b/projects/valtimo/components/src/lib/components/form-io/services/form-io-state.service.ts
@@ -50,4 +50,15 @@ export class FormIoStateService {
   public set currentForm(form: FormioComponent) {
     this._currentForm$.next(form);
   }
+
+  flattenTranslationsObject(translations, flattened = {}, prefix = '') {
+    for (const key in translations) {
+      if (typeof translations[key] === 'object' && translations[key] !== null) {
+        this.flattenTranslationsObject(translations[key], flattened, prefix + key + '.');
+      } else {
+        flattened[prefix + key] = translations[key];
+      }
+    }
+    return flattened;
+  }
 }

--- a/projects/valtimo/components/src/lib/models/form-io.model.ts
+++ b/projects/valtimo/components/src/lib/models/form-io.model.ts
@@ -52,6 +52,7 @@ export class FormioOptionsImpl implements ValtimoFormioOptions {
   errors?: ErrorsOptions;
   alerts?: AlertsOptions;
   disableAlerts?: boolean;
+  language?: string;
   i18n?: object;
   fileService?: object;
   hooks?: FormioHookOptions;

--- a/projects/valtimo/config/assets/core/de.json
+++ b/projects/valtimo/config/assets/core/de.json
@@ -1051,5 +1051,13 @@
     },
     "underscoresToSpaces": "Unterstriche zu Leerzeichen",
     "select": "Wählen Sie einen Anzeigetyp aus"
+  },
+  "formioTranslations": {
+    "Submit" : "Einreichen",
+    "Save": "Speichern",
+    "Cancel": "Stornieren",
+    "Remove": "Entfernen",
+    "Next": "Nächste",
+    "Previous": "Vorherige"
   }
 }

--- a/projects/valtimo/config/assets/core/en.json
+++ b/projects/valtimo/config/assets/core/en.json
@@ -1049,5 +1049,13 @@
       "list": "List",
       "searchFields": "Search Fields"
     }
+  },
+  "formioTranslations": {
+    "Submit" : "Submit",
+    "Save": "Save",
+    "Cancel": "Cancel",
+    "Remove": "Remove",
+    "Next": "Next",
+    "Previous": "Previous"
   }
 }

--- a/projects/valtimo/config/assets/core/nl.json
+++ b/projects/valtimo/config/assets/core/nl.json
@@ -1051,5 +1051,14 @@
     },
     "underscoresToSpaces": "Lage streepjes naar spaties",
     "select": "Selecteer een weergavetype"
+  },
+  "formioTranslations": {
+    "Submit" : "Versturen",
+    "Send": "Versturen",
+    "Save": "Opslaan",
+    "Cancel": "Annuleren",
+    "Remove": "Verwijderen",
+    "Next": "Volgende",
+    "Previous": "Vorige"
   }
 }


### PR DESCRIPTION
For one of the our projects we really need to be able to translate Formio forms which is currently not available. Formio already has a feature to translate things. Currently I have added only add some default translations which could increase in the feature. One of the downsides of the Formio translation is that they use a label as translation so implementation should probably always have some translations as well.