### PR TITLE
#57189 Download Document gives 'forbidden' error

### DIFF
--- a/projects/valtimo/resource/src/lib/services/download.service.ts
+++ b/projects/valtimo/resource/src/lib/services/download.service.ts
@@ -27,7 +27,8 @@ export class DownloadService {
   downloadFile(url: string, name: string) {
     if (
       url.startsWith(this.configService.config.valtimoApi.endpointUri) ||
-      url.startsWith(window.location.origin)
+      url.startsWith(window.location.origin) ||
+      url.startsWith('/api/')
     ) {
       // if download url is on backend use angular to get the content so access token is used
       this.http.get(url, {responseType: 'blob'}).subscribe(content => {


### PR DESCRIPTION
Problem:
Was in the downloadService.downloadFile(...). It expected the download-url to also contain a host part. While the new download-url didn't have a host and started with `/api/v1/...`
 

In some environments the downloading did work because those environments had `/api/` defined as `endpointUri` due to the setting below:
```
endpointUri: window['env']['apiUri'] || '/api/'
```