### PR TITLE
fix: object-list column type date formatting doesn't work

### DIFF
--- a/projects/valtimo/object/src/lib/components/object-list/object-list.component.ts
+++ b/projects/valtimo/object/src/lib/components/object-list/object-list.component.ts
@@ -214,6 +214,7 @@ export class ObjectListComponent {
               sortable: column.sortable,
               ...(column.viewType && {viewType: column.viewType}),
               ...(column.enum && {enum: column.enum}),
+              ...(column.format && {format: column.format}),
             };
           }),
         ];


### PR DESCRIPTION
#59913 