### PR TITLE
58008 - Loading extra entries in selectbox with paged endpoint

### DIFF
--- a/projects/valtimo/object-management/src/lib/components/object-management-modal/object-management-modal.component.html
+++ b/projects/valtimo/object-management/src/lib/components/object-management-modal/object-management-modal.component.html
@@ -132,27 +132,29 @@
         name="objecttypeVersion"
       ></v-input>
 
-      <ng-container *ngIf="{formDefinitions: formDefinitions$ | async} as formObs">
-        <v-select
-          [items]="formObs.formDefinitions"
-          [margin]="true"
-          [widthInPx]="350"
-          name="formDefinitionView"
-          [title]="'objectManagement.labels.formDefinitionView' | translate"
-          [tooltip]="'objectManagement.tooltips.formDefinitionView' | translate"
-          [defaultSelectionId]="prefillObject?.formDefinitionView"
-        ></v-select>
+      <v-select
+        [items]="formDefinitions"
+        [margin]="true"
+        [widthInPx]="350"
+        [typeahead]="searchInput$"
+        name="formDefinitionView"
+        [title]="'objectManagement.labels.formDefinitionView' | translate"
+        [tooltip]="'objectManagement.tooltips.formDefinitionView' | translate"
+        [defaultSelectionId]="prefillObject?.formDefinitionView"
+        (scrollToEnd)="fetchMoreForms($event)"
+      ></v-select>
 
-        <v-select
-          [items]="formObs.formDefinitions"
-          [margin]="true"
-          [widthInPx]="350"
-          name="formDefinitionEdit"
-          [title]="'objectManagement.labels.formDefinitionEdit' | translate"
-          [tooltip]="'objectManagement.tooltips.formDefinitionEdit' | translate"
-          [defaultSelectionId]="prefillObject?.formDefinitionEdit"
-        ></v-select>
-      </ng-container>
+      <v-select
+        [items]="formDefinitions"
+        [margin]="true"
+        [widthInPx]="350"
+        [typeahead]="searchInput$"
+        name="formDefinitionEdit"
+        [title]="'objectManagement.labels.formDefinitionEdit' | translate"
+        [tooltip]="'objectManagement.tooltips.formDefinitionEdit' | translate"
+        [defaultSelectionId]="prefillObject?.formDefinitionEdit"
+        (scrollToEnd)="fetchMoreForms($event)"
+      ></v-select>
 
       <v-input
         [margin]="true"

--- a/projects/valtimo/user-interface/src/lib/components/select/select.component.html
+++ b/projects/valtimo/user-interface/src/lib/components/select/select.component.html
@@ -25,6 +25,7 @@
   >
   </v-input-label>
   <ng-select
+    #select
     [style.width.px]="widthInPx"
     [ngModel]="selected$ | async"
     (ngModelChange)="setSelectedValue($event)"
@@ -34,9 +35,11 @@
     [notFoundText]="notFoundText || ('interface.noItemsFound' | translate)"
     [clearAllText]="clearAllText || ('interface.clearAll' | translate)"
     (clear)="clearSelection()"
+    (scrollToEnd)="scrollToEnd.emit(select.searchTerm)"
     [loading]="loading"
     [loadingText]="loadingText || ('interface.loading' | translate)"
     [placeholder]="placeholder"
+    [typeahead]="typeahead"
   >
     <ng-option *ngFor="let item of items" [value]="item.id">{{
       item.translationKey ? (item.translationKey | translate) : item.text

--- a/projects/valtimo/user-interface/src/lib/components/select/select.component.ts
+++ b/projects/valtimo/user-interface/src/lib/components/select/select.component.ts
@@ -25,7 +25,7 @@ import {
   SimpleChanges,
 } from '@angular/core';
 import {SelectedValue, SelectItem} from '../../models';
-import {BehaviorSubject, Observable, Subscription} from 'rxjs';
+import {BehaviorSubject, Observable, Subject, Subscription} from 'rxjs';
 
 @Component({
   selector: 'v-select',
@@ -54,9 +54,11 @@ export class SelectComponent implements OnInit, OnChanges, OnDestroy {
   @Input() loadingText = '';
   @Input() placeholder = '';
   @Input() smallMargin = false;
+  @Input() typeahead: Subject<string> = new Subject<string>();
 
   @Output() selectedChange: EventEmitter<SelectedValue> = new EventEmitter();
   @Output() clear: EventEmitter<any> = new EventEmitter();
+  @Output() scrollToEnd: EventEmitter<any> = new EventEmitter();
 
   selected$ = new BehaviorSubject<SelectedValue>('');
 


### PR DESCRIPTION
There was a  bug in the object management edit page where a dropdown was filled with values from a paged endpoint. This caused only 25 entries to be loaded with the other ones being unavailable. This fix will fetch another page of results and append them to the list in the drop down when scrolled to the end. When searching in the dropdown the backend is used to make sure the relevant entries are found.