### PR TITLE
Fixed secret toggling visibility in plugin edit

### DIFF
--- a/projects/valtimo/user-interface/src/lib/components/input/input.component.html
+++ b/projects/valtimo/user-interface/src/lib/components/input/input.component.html
@@ -55,6 +55,7 @@
     [min]="0"
     [name]="name"
     [maxLength]="maxLength"
+    (keydown)="onKeydown($event)"
   />
 </ng-template>
 
@@ -73,6 +74,7 @@
     (ngModelChange)="onValueChange($event)"
     [rows]="rows"
     [name]="name"
+    (keydown)="onKeydown($event)"
   ></textarea>
 </ng-template>
 
@@ -101,12 +103,13 @@
         [min]="0"
         [name]="name"
         [maxLength]="maxLength"
+        (keydown)="onKeydown($event)"
       />
       <div class="v-input__password-icon">
         <v-button
           [mdiIcon]="obs.showPassword ? 'eye-off' : 'eye'"
           type="icon-grey-small"
-          (click)="toggleShowPassword()"
+          (clickEvent)="toggleShowPassword()"
         ></v-button>
       </div>
     </div>
@@ -132,6 +135,7 @@
     [min]="min"
     [name]="name"
     [maxLength]="maxLength"
+    (keydown)="onKeydown($event)"
   />
 </ng-template>
 
@@ -153,6 +157,7 @@
     [min]="0"
     [name]="name"
     [maxLength]="maxLength"
+    (keydown)="onKeydown($event)"
     digitOnly
   />
 </ng-template>

--- a/projects/valtimo/user-interface/src/lib/components/input/input.component.ts
+++ b/projects/valtimo/user-interface/src/lib/components/input/input.component.ts
@@ -93,6 +93,14 @@ export class InputComponent implements OnInit, OnChanges, OnDestroy {
     this.clearSubscription?.unsubscribe();
   }
 
+  onKeydown(event: KeyboardEvent): void {
+    if (event.code !== 'Enter') {
+      return;
+    }
+
+    event.preventDefault();
+  }
+
   toggleShowPassword(): void {
     this.showPassword$.pipe(take(1)).subscribe(showPassword => {
       this.showPassword$.next(!showPassword);


### PR DESCRIPTION
[#69734 - Toggling secrets for plugin configurations works too well](https://ritense.tpondemand.com/RestUI/Board.aspx#page=board/4639300884032967758&appConfig=eyJhY2lkIjoiOEVGQ0YwMkI3RDlCQjhCQkQ4RTE3RkUwNkNCMkI3N0UifQ==&boardPopup=bug/69734/silent)