### PR TITLE
#69730 - [FE] Plugin configuration modal closes when failed to create plugin

### DIFF
--- a/projects/valtimo/plugin-management/src/lib/components/plugin-add-modal/plugin-add-modal.component.ts
+++ b/projects/valtimo/plugin-management/src/lib/components/plugin-add-modal/plugin-add-modal.component.ts
@@ -84,16 +84,15 @@ export class PluginAddModalComponent implements OnInit {
           title: configuration.configurationTitle,
           properties: pluginConfiguration,
         })
-        .subscribe(
-          response => {
+        .subscribe({
+          next: () => {
             this.stateService.refresh();
             this.hide();
           },
-          () => {
+          error: () => {
             this.logger.error('Something went wrong with saving the plugin configuration.');
-            this.hide();
-          }
-        );
+          },
+        });
     });
   }
 


### PR DESCRIPTION
[[FE] Plugin configuration modal closes when failed to create plugin](https://ritense.tpondemand.com/RestUI/Board.aspx#page=board/5184742957553134816&appConfig=eyJhY2lkIjoiN0ZFNjYyMjVDRUZFQUI0RTU1MEJBRkZERDkxMDQwN0IifQ==&boardPopup=bug/69730/silent)