### PR TITLE
Added field to configure 'Number of days for the task to expire'

### DIFF
--- a/projects/valtimo/plugin/src/lib/plugins/portaaltaak/components/create-portal-task/create-portal-task.component.html
+++ b/projects/valtimo/plugin/src/lib/plugins/portaaltaak/components/create-portal-task/create-portal-task.component.html
@@ -111,4 +111,14 @@
     [tooltip]="'identificationValueTooltip' | pluginTranslate : pluginId | async"
     [required]="true"
   ></v-input>
+  <v-input
+    name="verloopDurationInDays"
+    [type]="'number'"
+    [title]="'verloopDurationInDays' | pluginTranslate : pluginId | async"
+    [margin]="true"
+    [defaultValue]="obs.prefill?.verloopDurationInDays?.toString()"
+    [disabled]="obs.disabled"
+    [tooltip]="'verloopDurationInDaysTooltip' | pluginTranslate : pluginId | async"
+    [required]="false"
+  ></v-input>
 </v-form>

--- a/projects/valtimo/plugin/src/lib/plugins/portaaltaak/models/config.ts
+++ b/projects/valtimo/plugin/src/lib/plugins/portaaltaak/models/config.ts
@@ -36,6 +36,7 @@ interface CreatePortalTaskConfig {
   receiver: Receiver;
   identificationKey?: string;
   identificationValue?: string;
+  verloopDurationInDays?: number;
 }
 
 export {PortaaltaakConfig, CreatePortalTaskConfig, FormType, Receiver, OtherReceiver};

--- a/projects/valtimo/plugin/src/lib/plugins/portaaltaak/portaaltaak-plugin.specification.ts
+++ b/projects/valtimo/plugin/src/lib/plugins/portaaltaak/portaaltaak-plugin.specification.ts
@@ -78,6 +78,9 @@ const portaaltaakPluginSpecification: PluginSpecification = {
       identificationValue: 'Identificatiewaarde',
       identificationValueTooltip:
         "De waarde waarmee de ontvanger wordt geïdentificeerd. Wanneer er bijvoorbeeld in het veld 'Identificatiesleutel' de waarde 'bsn' is ingevoerd, kan er in dit veld een burgerservicenummer worden ingevoerd (bijvoorbeeld 558099476).",
+      verloopDurationInDays: 'Verlooptijd taak in dagen',
+      verloopDurationInDaysTooltip:
+        "Het aantal dagen na aanmaken van een taak dat deze verloopt. Deze wordt alleen ingesteld voor de portaal taak, niet in het BPMN proces.",
     },
     en: {
       title: 'Portal task',
@@ -128,6 +131,9 @@ const portaaltaakPluginSpecification: PluginSpecification = {
       identificationValue: 'Identification value',
       identificationValueTooltip:
         "The value that identifies the recipient. For example, if the value 'bsn' is entered in the 'Identification key' field, a citizen service number can be entered in this field (for example 558099476).",
+      verloopDurationInDays: 'Number of days for the task to expire',
+      verloopDurationInDaysTooltip:
+        "The number of days from the creation time until the task expires. This will only be used in the portal task. The BPMN due date needs to be configured separately.",
     },
     de: {
       title: 'Portalaufgabe',
@@ -176,6 +182,9 @@ const portaaltaakPluginSpecification: PluginSpecification = {
       identificationValue: 'Identifikationswert',
       identificationValueTooltip:
         "Der Wert, der den Empfänger identifiziert. Wird beispielsweise im Feld 'Identifikationsschlüssel' der Wert 'bsn' eingetragen, kann in diesem Feld eine Sozialversicherungsnummer eingetragen werden (z. B. 558099476).",
+      verloopDurationInDays: 'Ablaufzeit der Aufgabe in Tagen',
+      verloopDurationInDaysTooltip:
+        "Die Anzahl der Tage vom Erstellungszeitpunkt bis zum Ablauf der Aufgabe. Dies wird nur in der Portalaufgabe verwendet. Das BPMN-Fälligkeitsdatum muss separat konfiguriert werden.",
     },
   },
 };


### PR DESCRIPTION
[#84768 [BE + FE] Add 'zaak' and 'due date' properties to Portaaltaak object](https://ritense.tpondemand.com/entity/84768-be-fe-add-zaak-and-due)

Added a field to the 'create-portaaltaak' plugin action of the 'portaaltaak' plugin, which is used to set the expiration date of the task.