### PR TITLE
Added confirmation modal on leaving edit page

### DIFF
--- a/projects/valtimo/components/src/lib/components/page-title/page-title.component.ts
+++ b/projects/valtimo/components/src/lib/components/page-title/page-title.component.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import {
   AfterViewInit,
   Component,
@@ -23,13 +22,20 @@ import {
   ViewContainerRef,
   ViewEncapsulation,
 } from '@angular/core';
-import {ActivatedRoute, Router} from '@angular/router';
 import {Title} from '@angular/platform-browser';
-import {BehaviorSubject, combineLatest, Observable, startWith, Subscription, switchMap} from 'rxjs';
+import {ActivatedRoute, Router} from '@angular/router';
 import {TranslateService} from '@ngx-translate/core';
-import {NGXLogger} from 'ngx-logger';
 import {ConfigService} from '@valtimo/config';
-import {map} from 'rxjs/operators';
+import {NGXLogger} from 'ngx-logger';
+import {
+  BehaviorSubject,
+  combineLatest,
+  Observable,
+  startWith,
+  Subscription,
+  switchMap,
+  map,
+} from 'rxjs';
 import {PageTitleService} from './page-title.service';
 
 @Component({

--- a/projects/valtimo/components/src/lib/components/page-title/page-title.service.ts
+++ b/projects/valtimo/components/src/lib/components/page-title/page-title.service.ts
@@ -111,7 +111,7 @@ export class PageTitleService implements OnDestroy {
             event instanceof NavigationStart ||
             event instanceof ResolveEnd
         ),
-        tap(([event, pageActionsViewContainerRef]) => {
+        tap(([_, pageActionsViewContainerRef]) => {
           if (!this._preventReset) {
             this._customPageTitle$.next('');
             this._customPageTitleSet$.next(false);

--- a/projects/valtimo/components/src/lib/components/pending-changes/pending-changes.component.ts
+++ b/projects/valtimo/components/src/lib/components/pending-changes/pending-changes.component.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015-2023 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {UrlTree} from '@angular/router';
+import {TranslateService} from '@ngx-translate/core';
+import {ModalButtonType, ModalService} from 'carbon-components-angular';
+import {Observable, Subject} from 'rxjs';
+
+export class PendingChangesComponent {
+  public pendingChanges = false;
+
+  constructor(
+    protected readonly modalService: ModalService,
+    protected readonly translateService: TranslateService
+  ) {}
+
+  public canDeactivate():
+    | Observable<boolean | UrlTree>
+    | Promise<boolean | UrlTree>
+    | boolean
+    | UrlTree {
+    if (!this.pendingChanges) {
+      return true;
+    }
+
+    const deactivateSubject = new Subject<boolean>();
+
+    this.modalService.show({
+      title: this.translateService.instant('interface.pendingChanges.title'),
+      content: this.translateService.instant('interface.pendingChanges.content'),
+      buttons: [
+        {
+          text: this.translateService.instant('interface.cancel'),
+          type: ModalButtonType.secondary,
+          click: () => {
+            deactivateSubject.next(false);
+          },
+        },
+        {
+          text: this.translateService.instant('interface.confirm'),
+          type: ModalButtonType.primary,
+          click: () => {
+            deactivateSubject.next(true);
+          },
+        },
+      ],
+    });
+
+    return deactivateSubject;
+  }
+}

--- a/projects/valtimo/components/src/lib/guards/index.ts
+++ b/projects/valtimo/components/src/lib/guards/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2015-2023 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './pending-changes.guard';

--- a/projects/valtimo/components/src/lib/guards/pending-changes.guard.ts
+++ b/projects/valtimo/components/src/lib/guards/pending-changes.guard.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015-2023 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {CanDeactivateFn} from '@angular/router';
+
+import {PendingChangesComponent} from '../components/pending-changes/pending-changes.component';
+
+export const pendingChangesGuard: CanDeactivateFn<PendingChangesComponent> = (
+  component: PendingChangesComponent
+) => component.canDeactivate();

--- a/projects/valtimo/components/src/public_api.ts
+++ b/projects/valtimo/components/src/public_api.ts
@@ -22,6 +22,7 @@ export * from './lib/models';
 export * from './lib/constants';
 export * from './lib/pipes';
 export * from './lib/services';
+export * from './lib/guards';
 
 /*
 components
@@ -218,6 +219,9 @@ export * from './lib/components/multi-input-form/multi-input-form.module';
 // Radio
 export * from './lib/components/radio/radio.component';
 export * from './lib/components/radio/radio.module';
+
+// Pending Changes
+export * from './lib/components/pending-changes/pending-changes.component';
 
 /*
 directives

--- a/projects/valtimo/config/assets/core/de.json
+++ b/projects/valtimo/config/assets/core/de.json
@@ -596,6 +596,7 @@
     "delete": "Löschen",
     "deleteConfirmation": "Sind Sie sicher, dass Sie löschen möchten?",
     "cancel": "Absagen",
+    "confirm": "Bestätigen",
     "collapse": "Kollaps",
     "expand": "Expandieren",
     "download": "Herunterladen",
@@ -611,6 +612,10 @@
       "ofLastPages": "von {{last}} Seiten",
       "singleSelect": "1 Element ausgewählt",
       "totalItems": "{{start}}-{{end}} von {{total}} Objekte"
+    },
+    "pendingChanges": {
+      "title": "Seite verlassen",
+      "content": "Du hast nicht gespeicherte Änderungen. Bist du dir sicher, dass du weitermachen willst?"
     },
     "required": "erforderlich",
     "filter": "Filter...",

--- a/projects/valtimo/config/assets/core/en.json
+++ b/projects/valtimo/config/assets/core/en.json
@@ -597,6 +597,7 @@
     "delete": "Delete",
     "deleteConfirmation": "Are you sure you want to delete?",
     "cancel": "Cancel",
+    "confirm": "Confirm",
     "collapse": "Collapse",
     "expand": "Expand",
     "download": "Download",
@@ -612,6 +613,10 @@
       "ofLastPages": "of {{last}} pages",
       "singleSelect": "1 item selected",
       "totalItems": "{{start}}-{{end}} of {{total}} items"
+    },
+    "pendingChanges": {
+      "title": "Leaving page",
+      "content": "You have unsaved changes. Are you sure you want to continue?"
     },
     "required": "required",
     "filter": "Filter...",

--- a/projects/valtimo/config/assets/core/nl.json
+++ b/projects/valtimo/config/assets/core/nl.json
@@ -596,6 +596,7 @@
     "delete": "Verwijderen",
     "deleteConfirmation": "Weet u zeker dat u wilt verwijderen?",
     "cancel": "Annuleren",
+    "confirm": "Bevestigen",
     "collapse": "Inklappen",
     "expand": "Uitklappen",
     "download": "Download",
@@ -611,6 +612,10 @@
       "ofLastPages": "van {{last}} pagina's",
       "singleSelect": "1 artikel geselecteerd",
       "totalItems": "{{start}}-{{end}} van {{total}} artikelen"
+    },
+    "pendingChanges": {
+      "title": "Pagina verlaten",
+      "content": "Jij heeft niet-opgeslagen wijzigingen. Weet je zeker dat je door wilt gaan?"
     },
     "required": "vereist",
     "filter": "Filteren...",

--- a/projects/valtimo/form-management/src/lib/form-management-edit/form-management-edit.component.ts
+++ b/projects/valtimo/form-management/src/lib/form-management-edit/form-management-edit.component.ts
@@ -13,17 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import {Component, OnDestroy, OnInit, ViewEncapsulation} from '@angular/core';
-import {FormManagementService} from '../form-management.service';
-import {AlertService, PageTitleService} from '@valtimo/components';
-import {FormDefinition, ModifyFormDefinitionRequest} from '../models';
 import {ActivatedRoute, Router} from '@angular/router';
-import {first, take} from 'rxjs/operators';
-import {BehaviorSubject, Subscription} from 'rxjs';
 import {FormioForm} from '@formio/angular';
-import {FormManagementDuplicateComponent} from '../form-management-duplicate/form-management-duplicate.component';
+import {TranslateService} from '@ngx-translate/core';
+import {AlertService, PageTitleService, PendingChangesComponent} from '@valtimo/components';
 import {ModalService} from 'carbon-components-angular';
+import {BehaviorSubject, Subscription} from 'rxjs';
+import {first, take} from 'rxjs/operators';
+import {FormManagementDuplicateComponent} from '../form-management-duplicate/form-management-duplicate.component';
+import {FormManagementService} from '../form-management.service';
+import {FormDefinition, ModifyFormDefinitionRequest} from '../models';
 
 @Component({
   selector: 'valtimo-form-management-edit',
@@ -31,48 +31,61 @@ import {ModalService} from 'carbon-components-angular';
   styleUrls: ['./form-management-edit.component.scss'],
   encapsulation: ViewEncapsulation.None,
 })
-export class FormManagementEditComponent implements OnInit, OnDestroy {
-  readonly showModal$ = new BehaviorSubject<boolean>(false);
-  readonly reloading$ = new BehaviorSubject<boolean>(false);
-  public modifiedFormDefinition: FormioForm = null;
+export class FormManagementEditComponent
+  extends PendingChangesComponent
+  implements OnInit, OnDestroy
+{
+  public modifiedFormDefinition: FormioForm | null = null;
   public formDefinition: FormDefinition | null = null;
-  private alertSub: Subscription = Subscription.EMPTY;
-  private formDefinitionId: string | null = null;
+
+  public readonly showModal$ = new BehaviorSubject<boolean>(false);
+  public readonly reloading$ = new BehaviorSubject<boolean>(false);
+
+  private _alertSub: Subscription = Subscription.EMPTY;
+  private _formDefinitionId: string | null = null;
 
   constructor(
-    private readonly formManagementService: FormManagementService,
+    protected readonly modalService: ModalService,
+    protected readonly translateService: TranslateService,
     private readonly alertService: AlertService,
+    private readonly formManagementService: FormManagementService,
+    private readonly pageTitleService: PageTitleService,
     private readonly route: ActivatedRoute,
-    private readonly router: Router,
-    private readonly modalService: ModalService,
-    private readonly pageTitleService: PageTitleService
-  ) {}
+    private readonly router: Router
+  ) {
+    super(modalService, translateService);
+  }
 
-  ngOnInit() {
+  public ngOnInit(): void {
+    this.pageTitleService.disableReset();
     this.loadFormDefinition();
     this.checkToOpenUploadModal();
   }
 
-  ngOnDestroy() {
-    this.alertSub.unsubscribe();
+  public ngOnDestroy(): void {
+    this._alertSub.unsubscribe();
   }
 
-  loadFormDefinition() {
-    this.formDefinitionId = this.route.snapshot.paramMap.get('id');
-    this.formManagementService.getFormDefinition(this.formDefinitionId).subscribe(
-      formDefinition => {
+  public loadFormDefinition(): void {
+    this._formDefinitionId = this.route.snapshot.paramMap.get('id');
+    this.formManagementService.getFormDefinition(this._formDefinitionId ?? '').subscribe({
+      next: formDefinition => {
         this.formDefinition = formDefinition;
         this.pageTitleService.setCustomPageTitle(formDefinition.name);
       },
-      () => {
+      error: () => {
         this.alertService.error('Error retrieving Form Definition');
-      }
-    );
+      },
+    });
   }
 
-  modifyFormDefinition() {
+  public modifyFormDefinition(): void {
+    if (!this.formDefinition) {
+      return;
+    }
+
     const form = JSON.stringify(
-      this.modifiedFormDefinition != null
+      this.modifiedFormDefinition !== null
         ? this.modifiedFormDefinition
         : this.formDefinition.formDefinition
     );
@@ -81,23 +94,24 @@ export class FormManagementEditComponent implements OnInit, OnDestroy {
       name: this.formDefinition.name,
       formDefinition: form,
     };
-    this.formManagementService.modifyFormDefinition(request).subscribe(
-      () => {
+    this.formManagementService.modifyFormDefinition(request).subscribe({
+      next: () => {
         this.router.navigate(['/form-management']);
         this.alertService.success('Form deployed');
       },
-      err => {
+      error: () => {
         this.alertService.error('Error deploying Form');
-      }
-    );
+      },
+    });
   }
 
-  public formBuilderChanged(event) {
+  public formBuilderChanged(event): void {
+    this.pendingChanges = true;
     this.modifiedFormDefinition = event.form;
   }
 
-  public delete() {
-    if (!this.alertSub.closed) {
+  public delete(): void {
+    if (!this._alertSub.closed) {
       return;
     }
     const mssg = 'Delete Form?';
@@ -114,7 +128,8 @@ export class FormManagementEditComponent implements OnInit, OnDestroy {
       },
     ];
     this.alertService.notification(mssg, confirmations);
-    this.alertSub = this.alertService
+
+    this._alertSub = this.alertService
       .getAlertConfirmChangeEmitter()
       .pipe(first())
       .subscribe(alert => {
@@ -124,19 +139,27 @@ export class FormManagementEditComponent implements OnInit, OnDestroy {
       });
   }
 
-  deleteFormDefinition() {
-    this.formManagementService.deleteFormDefinition(this.formDefinition.id).subscribe(
-      () => {
+  public deleteFormDefinition(): void {
+    if (!this.formDefinition) {
+      return;
+    }
+
+    this.formManagementService.deleteFormDefinition(this.formDefinition.id).subscribe({
+      next: () => {
         this.router.navigate(['/form-management']);
         this.alertService.success('Form deleted');
       },
-      err => {
+      error: () => {
         this.alertService.error('Error deleting Form');
-      }
-    );
+      },
+    });
   }
 
-  downloadFormDefinition() {
+  public downloadFormDefinition(): void {
+    if (!this.formDefinition) {
+      return;
+    }
+
     const file = new Blob([JSON.stringify(this.formDefinition.formDefinition)], {
       type: 'text/json',
     });
@@ -148,11 +171,11 @@ export class FormManagementEditComponent implements OnInit, OnDestroy {
     link.remove();
   }
 
-  showUploadModal() {
+  public showUploadModal(): void {
     this.showModal$.next(true);
   }
 
-  showDuplicateModal() {
+  public showDuplicateModal(): void {
     this.modalService.create({
       component: FormManagementDuplicateComponent,
       inputs: {
@@ -161,23 +184,28 @@ export class FormManagementEditComponent implements OnInit, OnDestroy {
     });
   }
 
-  setFormDefinition(formDefinition: any) {
+  public setFormDefinition(formDefinition: any): void {
     this.reloading$.next(true);
 
     const definition = JSON.parse(formDefinition);
     if (!definition?.components) {
       this.reloading$.next(false);
       this.alertService.error('Invalid form.io. Missing JSON field "components".');
-    } else {
-      const components = definition.components;
-      const currentDefinition = this.modifiedFormDefinition || this.formDefinition.formDefinition;
-      const newDefinition = {...currentDefinition, ...(components && {components})};
-
-      this.modifiedFormDefinition = newDefinition;
-      this.formDefinition.formDefinition = newDefinition;
-
-      this.reloading$.next(false);
+      return;
     }
+
+    if (!this.formDefinition) {
+      return;
+    }
+
+    const components = definition.components;
+    const currentDefinition = this.modifiedFormDefinition || this.formDefinition.formDefinition;
+    const newDefinition = {...currentDefinition, ...(components && {components})};
+
+    this.modifiedFormDefinition = newDefinition;
+    this.formDefinition.formDefinition = newDefinition;
+
+    this.reloading$.next(false);
   }
 
   private checkToOpenUploadModal(): void {

--- a/projects/valtimo/form-management/src/lib/form-management-routing.module.ts
+++ b/projects/valtimo/form-management/src/lib/form-management-routing.module.ts
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import {NgModule} from '@angular/core';
 import {RouterModule, Routes} from '@angular/router';
-import {FormManagementComponent} from './form-management.component';
+import {pendingChangesGuard} from '@valtimo/components';
+import {ROLE_ADMIN} from '@valtimo/config';
 import {AuthGuardService} from '@valtimo/security';
 import {FormManagementCreateComponent} from './form-management-create/form-management-create.component';
 import {FormManagementEditComponent} from './form-management-edit/form-management-edit.component';
-import {ROLE_ADMIN} from '@valtimo/config';
+import {FormManagementComponent} from './form-management.component';
 
 const routes: Routes = [
   {
@@ -39,6 +39,7 @@ const routes: Routes = [
     path: 'form-management/edit/:id',
     component: FormManagementEditComponent,
     canActivate: [AuthGuardService],
+    canDeactivate: [pendingChangesGuard],
     data: {title: 'Form Builder', roles: [ROLE_ADMIN], customPageTitle: true},
   },
 ];


### PR DESCRIPTION
[[FE] Going 'Back' when editing a form component results in data-loss and a non-usable UI](https://ritense.tpondemand.com/entity/83410-fe-going-back-when-editing-a)

Added component and guard in '@valtimo/components' for future use