### PR TITLE
added admin endpoint for retrieving process document definitions

### DIFF
--- a/projects/valtimo/document/src/lib/document.service.ts
+++ b/projects/valtimo/document/src/lib/document.service.ts
@@ -272,6 +272,14 @@ export class DocumentService {
     );
   }
 
+  public findProcessDocumentDefinitionsAdmin(
+    documentDefinitionName: string
+  ): Observable<ProcessDocumentDefinition[]> {
+    return this.http.get<ProcessDocumentDefinition[]>(
+      `${this.valtimoEndpointUri}management/v1/process-document/definition/document/${documentDefinitionName}`
+    );
+  }
+
   public findProcessDocumentDefinitionsByProcessDefinitionKey(
     processDefinitionKey: string
   ): Observable<ProcessDocumentDefinition[]> {

--- a/projects/valtimo/dossier-management/src/lib/components/dossier-management-connect-modal/dossier-management-connect-modal.component.ts
+++ b/projects/valtimo/dossier-management/src/lib/components/dossier-management-connect-modal/dossier-management-connect-modal.component.ts
@@ -49,7 +49,7 @@ export class DossierManagementConnectModalComponent implements OnInit {
   loadProcessDocumentDefinitions() {
     this.processDocumentDefinitionExists = {};
     this.documentService
-      .findProcessDocumentDefinitions(this.documentDefinition.id.name)
+      .findProcessDocumentDefinitionsAdmin(this.documentDefinition.id.name)
       .subscribe((processDocumentDefinitions: ProcessDocumentDefinition[]) => {
         processDocumentDefinitions.forEach(
           (processDocumentDefinition: ProcessDocumentDefinition) => {

--- a/projects/valtimo/dossier-management/src/lib/components/dossier-management-detail/dossier-management-detail.component.ts
+++ b/projects/valtimo/dossier-management/src/lib/components/dossier-management-detail/dossier-management-detail.component.ts
@@ -52,7 +52,7 @@ export class DossierManagementDetailComponent implements OnInit {
 
   public loadProcessDocumentDefinitions(): void {
     this.documentService
-      .findProcessDocumentDefinitions(this.documentDefinitionName)
+      .findProcessDocumentDefinitionsAdmin(this.documentDefinitionName)
       .subscribe((processDocumentDefinitions: ProcessDocumentDefinition[]) => {
         this.processDocumentDefinitions = processDocumentDefinitions;
       });


### PR DESCRIPTION
Added admin endpoint to retrieve process document definitions + made management pages use this. Also see [this BE pr](https://github.com/valtimo-platform/valtimo-backend-libraries/pull/1136).