### PR TITLE
fix: menu item text shows null on page load

### DIFF
--- a/projects/valtimo/components/src/lib/components/menu/menu-item-text.component.html
+++ b/projects/valtimo/components/src/lib/components/menu/menu-item-text.component.html
@@ -19,7 +19,7 @@
   class="menu-item-text-container"
   id="{{ menuItem?.id }}"
 >
-  <span [ngClass]="{'cds--link empty-menu-icon-text': accent}">
+  <span *ngIf="obs.titleTranslation" [ngClass]="{'cds--link empty-menu-icon-text': accent}">
     <div class="menu-item-icon-container">
       <i class="{{ menuItem.iconClass }}"></i>
     </div>


### PR DESCRIPTION
closes https://ritense.tpondemand.com/entity/93307-fe-menu-items-show-as-null