### PR TITLE
- Added StartModalService with function to get title from start event…

### DIFF
--- a/projects/valtimo/config/src/lib/models/config.ts
+++ b/projects/valtimo/config/src/lib/models/config.ts
@@ -124,6 +124,7 @@ export interface ValtimoConfig {
     returnToLastUrlAfterTokenExpiration?: boolean;
     enableTabManagement?: boolean;
     hideValtimoVersionsForNonAdmins?: boolean;
+    useStartEventNameAsStartFormTitle?: boolean;
   };
   visibleTaskListTabs?: Array<TaskListTab>;
   visibleDossierListTabs?: Array<DossierListTab>;

--- a/projects/valtimo/dossier/src/lib/components/dossier-process-start-modal/dossier-process-start-modal.component.ts
+++ b/projects/valtimo/dossier/src/lib/components/dossier-process-start-modal/dossier-process-start-modal.component.ts
@@ -34,6 +34,7 @@ import {take} from 'rxjs/operators';
 import {CAN_VIEW_CASE_PERMISSION, DOSSIER_DETAIL_PERMISSION_RESOURCE} from '../../permissions';
 import {DossierListService} from '../../services';
 import {StartModalService} from '../../services/start-modal.service';
+import {ConfigService} from '@valtimo/config';
 
 @Component({
   selector: 'valtimo-dossier-process-start-modal',
@@ -46,6 +47,7 @@ export class DossierProcessStartModalComponent implements OnInit {
   public processDefinitionId: string;
   public documentDefinitionName: string;
   public processName: string;
+  public startEventName: string;
   public formDefinition: FormioForm;
   public formFlowInstanceId: string;
   public formioSubmission: FormioSubmission;
@@ -66,8 +68,10 @@ export class DossierProcessStartModalComponent implements OnInit {
     private userProviderService: UserProviderService,
     private permissionService: PermissionService,
     private listService: DossierListService,
-    private startModalService: StartModalService
-  ) {}
+    private startModalService: StartModalService,
+    private configService: ConfigService
+  ) {
+  }
 
   ngOnInit() {
     this.isUserAdmin();
@@ -77,6 +81,9 @@ export class DossierProcessStartModalComponent implements OnInit {
     this.processLinkId = null;
     this.formDefinition = null;
     this.formFlowInstanceId = null;
+    this.processService.getProcessDefinitionXml(this.processDefinitionId).subscribe((result) => {
+      this.startEventName = this.startModalService.getStandardStartEventTitle(result.bpmn20Xml);
+    });
     this.processService
       .getProcessDefinitionStartProcessLink(
         this.processDefinitionId,
@@ -106,9 +113,8 @@ export class DossierProcessStartModalComponent implements OnInit {
   }
 
   public get modalTitle() {
-    this.processService.getProcessDefinitionXml(this.processDefinitionId).subscribe((result) => {
-      return this.startModalService.getStandardStartEventTitle(result.bpmn20Xml) || `Start - ${this.processName}`;
-    });
+    return this.configService.config.featureToggles?.useStartEventNameAsStartFormTitle ?
+      (this.startEventName || `Start - ${this.processName}`) : `Start - ${this.processName}`;
   }
 
   openModal(processDocumentDefinition: ProcessDocumentDefinition) {

--- a/projects/valtimo/dossier/src/lib/components/dossier-process-start-modal/dossier-process-start-modal.component.ts
+++ b/projects/valtimo/dossier/src/lib/components/dossier-process-start-modal/dossier-process-start-modal.component.ts
@@ -33,6 +33,7 @@ import {UserProviderService} from '@valtimo/security';
 import {take} from 'rxjs/operators';
 import {CAN_VIEW_CASE_PERMISSION, DOSSIER_DETAIL_PERMISSION_RESOURCE} from '../../permissions';
 import {DossierListService} from '../../services';
+import {StartModalService} from '../../services/start-modal.service';
 
 @Component({
   selector: 'valtimo-dossier-process-start-modal',
@@ -64,7 +65,8 @@ export class DossierProcessStartModalComponent implements OnInit {
     private formFlowService: FormFlowService,
     private userProviderService: UserProviderService,
     private permissionService: PermissionService,
-    private listService: DossierListService
+    private listService: DossierListService,
+    private startModalService: StartModalService
   ) {}
 
   ngOnInit() {
@@ -104,7 +106,9 @@ export class DossierProcessStartModalComponent implements OnInit {
   }
 
   public get modalTitle() {
-    return `Start - ${this.processName}`;
+    this.processService.getProcessDefinitionXml(this.processDefinitionId).subscribe((result) => {
+      return this.startModalService.getStandardStartEventTitle(result.bpmn20Xml) || `Start - ${this.processName}`;
+    });
   }
 
   openModal(processDocumentDefinition: ProcessDocumentDefinition) {

--- a/projects/valtimo/dossier/src/lib/components/dossier-process-start-modal/dossier-process-start-modal.component.ts
+++ b/projects/valtimo/dossier/src/lib/components/dossier-process-start-modal/dossier-process-start-modal.component.ts
@@ -113,8 +113,9 @@ export class DossierProcessStartModalComponent implements OnInit {
   }
 
   public get modalTitle() {
+    const fallbackTitle = `Start - ${this.processName}`;
     return this.configService.config.featureToggles?.useStartEventNameAsStartFormTitle ?
-      (this.startEventName || `Start - ${this.processName}`) : `Start - ${this.processName}`;
+      (this.startEventName || fallbackTitle) : fallbackTitle;
   }
 
   openModal(processDocumentDefinition: ProcessDocumentDefinition) {

--- a/projects/valtimo/dossier/src/lib/components/dossier-process-start-modal/dossier-process-start-modal.component.ts
+++ b/projects/valtimo/dossier/src/lib/components/dossier-process-start-modal/dossier-process-start-modal.component.ts
@@ -48,6 +48,7 @@ export class DossierProcessStartModalComponent implements OnInit {
   public documentDefinitionName: string;
   public processName: string;
   public startEventName: string;
+  public useStartEventNameAsStartFormTitle: boolean;
   public formDefinition: FormioForm;
   public formFlowInstanceId: string;
   public formioSubmission: FormioSubmission;
@@ -71,6 +72,7 @@ export class DossierProcessStartModalComponent implements OnInit {
     private startModalService: StartModalService,
     private configService: ConfigService
   ) {
+    this.useStartEventNameAsStartFormTitle = this.configService.config.featureToggles?.useStartEventNameAsStartFormTitle
   }
 
   ngOnInit() {
@@ -81,7 +83,7 @@ export class DossierProcessStartModalComponent implements OnInit {
     this.processLinkId = null;
     this.formDefinition = null;
     this.formFlowInstanceId = null;
-    if (this.configService.config.featureToggles?.useStartEventNameAsStartFormTitle) {
+    if (this.useStartEventNameAsStartFormTitle) {
       this.processService.getProcessDefinitionXml(this.processDefinitionId).subscribe((result) => {
         this.startEventName = this.startModalService.getStandardStartEventTitle(result.bpmn20Xml);
       });
@@ -116,8 +118,7 @@ export class DossierProcessStartModalComponent implements OnInit {
 
   public get modalTitle() {
     const fallbackTitle = `Start - ${this.processName}`;
-    return this.configService.config.featureToggles?.useStartEventNameAsStartFormTitle ?
-      (this.startEventName || fallbackTitle) : fallbackTitle;
+    return this.useStartEventNameAsStartFormTitle ? (this.startEventName || fallbackTitle) : fallbackTitle;
   }
 
   openModal(processDocumentDefinition: ProcessDocumentDefinition) {

--- a/projects/valtimo/dossier/src/lib/components/dossier-process-start-modal/dossier-process-start-modal.component.ts
+++ b/projects/valtimo/dossier/src/lib/components/dossier-process-start-modal/dossier-process-start-modal.component.ts
@@ -47,8 +47,8 @@ export class DossierProcessStartModalComponent implements OnInit {
   public processDefinitionId: string;
   public documentDefinitionName: string;
   public processName: string;
-  public startEventName: string;
-  public useStartEventNameAsStartFormTitle: boolean;
+  private _startEventName: string;
+  private _useStartEventNameAsStartFormTitle!: boolean;
   public formDefinition: FormioForm;
   public formFlowInstanceId: string;
   public formioSubmission: FormioSubmission;
@@ -72,7 +72,7 @@ export class DossierProcessStartModalComponent implements OnInit {
     private startModalService: StartModalService,
     private configService: ConfigService
   ) {
-    this.useStartEventNameAsStartFormTitle = this.configService.config.featureToggles?.useStartEventNameAsStartFormTitle
+    this._useStartEventNameAsStartFormTitle = this.configService.config.featureToggles?.useStartEventNameAsStartFormTitle
   }
 
   ngOnInit() {
@@ -83,9 +83,9 @@ export class DossierProcessStartModalComponent implements OnInit {
     this.processLinkId = null;
     this.formDefinition = null;
     this.formFlowInstanceId = null;
-    if (this.useStartEventNameAsStartFormTitle) {
+    if (this._useStartEventNameAsStartFormTitle) {
       this.processService.getProcessDefinitionXml(this.processDefinitionId).subscribe((result) => {
-        this.startEventName = this.startModalService.getStandardStartEventTitle(result.bpmn20Xml);
+        this._startEventName = this.startModalService.getStandardStartEventTitle(result.bpmn20Xml);
       });
     }
     this.processService
@@ -118,7 +118,7 @@ export class DossierProcessStartModalComponent implements OnInit {
 
   public get modalTitle() {
     const fallbackTitle = `Start - ${this.processName}`;
-    return this.useStartEventNameAsStartFormTitle ? (this.startEventName || fallbackTitle) : fallbackTitle;
+    return this._useStartEventNameAsStartFormTitle ? (this._startEventName || fallbackTitle) : fallbackTitle;
   }
 
   openModal(processDocumentDefinition: ProcessDocumentDefinition) {

--- a/projects/valtimo/dossier/src/lib/components/dossier-process-start-modal/dossier-process-start-modal.component.ts
+++ b/projects/valtimo/dossier/src/lib/components/dossier-process-start-modal/dossier-process-start-modal.component.ts
@@ -48,7 +48,7 @@ export class DossierProcessStartModalComponent implements OnInit {
   public documentDefinitionName: string;
   public processName: string;
   private _startEventName: string;
-  private _useStartEventNameAsStartFormTitle!: boolean;
+  private readonly _useStartEventNameAsStartFormTitle!: boolean;
   public formDefinition: FormioForm;
   public formFlowInstanceId: string;
   public formioSubmission: FormioSubmission;

--- a/projects/valtimo/dossier/src/lib/components/dossier-process-start-modal/dossier-process-start-modal.component.ts
+++ b/projects/valtimo/dossier/src/lib/components/dossier-process-start-modal/dossier-process-start-modal.component.ts
@@ -81,9 +81,11 @@ export class DossierProcessStartModalComponent implements OnInit {
     this.processLinkId = null;
     this.formDefinition = null;
     this.formFlowInstanceId = null;
-    this.processService.getProcessDefinitionXml(this.processDefinitionId).subscribe((result) => {
-      this.startEventName = this.startModalService.getStandardStartEventTitle(result.bpmn20Xml);
-    });
+    if (this.configService.config.featureToggles?.useStartEventNameAsStartFormTitle) {
+      this.processService.getProcessDefinitionXml(this.processDefinitionId).subscribe((result) => {
+        this.startEventName = this.startModalService.getStandardStartEventTitle(result.bpmn20Xml);
+      });
+    }
     this.processService
       .getProcessDefinitionStartProcessLink(
         this.processDefinitionId,

--- a/projects/valtimo/dossier/src/lib/services/start-modal.service.ts
+++ b/projects/valtimo/dossier/src/lib/services/start-modal.service.ts
@@ -1,0 +1,39 @@
+import {HttpClient} from '@angular/common/http';
+import {Injectable} from '@angular/core';
+import {ConfigService} from '@valtimo/config';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class StartModalService {
+  private valtimoEndpointUri: string;
+
+  constructor(
+    private http: HttpClient,
+    private configService: ConfigService
+  ) {
+    this.valtimoEndpointUri = configService.config.valtimoApi.endpointUri;
+  }
+
+  getStandardStartEventTitle(bpmnXml: string): string | null {
+    const parser = new DOMParser();
+    const xmlDoc = parser.parseFromString(bpmnXml, "application/xml");
+
+    if (xmlDoc.getElementsByTagName("parsererror").length) {
+      console.error("Error parsing XML");
+      return null;
+    }
+
+    const startEvents = xmlDoc.getElementsByTagName('bpmn:startEvent');
+    if (!startEvents) {
+      return null;
+    }
+
+    const standardStartEvent = Array.from(startEvents).find(event =>
+      !event.getElementsByTagName('bpmn:messageEventDefinition').length &&
+      !event.getElementsByTagName('bpmn:timerEventDefinition').length
+    );
+
+    return standardStartEvent ? standardStartEvent.getAttribute('name') : null;
+  }
+}

--- a/projects/valtimo/dossier/src/lib/services/start-modal.service.ts
+++ b/projects/valtimo/dossier/src/lib/services/start-modal.service.ts
@@ -1,19 +1,9 @@
-import {HttpClient} from '@angular/common/http';
 import {Injectable} from '@angular/core';
-import {ConfigService} from '@valtimo/config';
 
 @Injectable({
   providedIn: 'root'
 })
 export class StartModalService {
-  private valtimoEndpointUri: string;
-
-  constructor(
-    private http: HttpClient,
-    private configService: ConfigService
-  ) {
-    this.valtimoEndpointUri = configService.config.valtimoApi.endpointUri;
-  }
 
   getStandardStartEventTitle(bpmnXml: string): string | null {
     const parser = new DOMParser();

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -250,6 +250,7 @@ export const environment: ValtimoConfig = {
     enableObjectManagement: true,
     returnToLastUrlAfterTokenExpiration: true,
     enableTabManagement: true,
+    useStartEventNameAsStartFormTitle: true
   },
   customDossierHeader: {
     leningen: [


### PR DESCRIPTION
- Added StartModalService with function to get title from start event to be used in start modal component.

- Modified start modal component to get modal title from start event. If no start event name found it will fall back to original 'start - ${process-name}' start form title format.