### PR TITLE
- Refactored custom dossier header code so it doesn't break when a pr…

### DIFF
--- a/projects/valtimo/dossier/src/lib/dossier-detail/dossier-detail.component.ts
+++ b/projects/valtimo/dossier/src/lib/dossier-detail/dossier-detail.component.ts
@@ -232,8 +232,7 @@ export class DossierDetailComponent implements OnInit, OnDestroy {
 
   private getStringFromDocumentPath(item, path): string {
     const prefix = item['propertyPaths'].indexOf(path) > 0 ? ' ' : '';
-    let string =
-      path.split('.').reduce((o, i) => o[i], this.document.content) || item['noValueText'] || '';
+    let string = this.getNestedProperty(this.document.content, path, item['noValueText']) || '';
     const dateFormats = [moment.ISO_8601, 'MM-DD-YYYY', 'DD-MM-YYYY', 'YYYY-MM-DD'];
     switch (item['modifier']) {
       case 'age': {
@@ -249,6 +248,10 @@ export class DossierDetailComponent implements OnInit, OnDestroy {
       }
     }
     return prefix + string;
+  }
+
+  private getNestedProperty(obj: any, path: string, defaultValue: any): any {
+    return path.split('.').reduce((currentObject, key) => currentObject?.[key], obj) || defaultValue;
   }
 
   private setBreadcrumb(): void {


### PR DESCRIPTION
- Refactored custom dossier header code so it doesn't break when a propertyPath is not found in the document. It will now just ignore that path when building a string of all combined paths.