### PR TITLE
Prevent dropdown in verzoek plugin configuration from breaking when a…

### DIFF
--- a/projects/valtimo/plugin/src/lib/plugins/verzoek/components/verzoek-configuration/verzoek-configuration.component.ts
+++ b/projects/valtimo/plugin/src/lib/plugins/verzoek/components/verzoek-configuration/verzoek-configuration.component.ts
@@ -86,7 +86,7 @@ export class VerzoekConfigurationComponent
       map(processDefinitions =>
         processDefinitions.map(processDefinition => ({
           id: processDefinition.key,
-          text: processDefinition.name,
+          text: processDefinition.name ?? '',
         }))
       )
     );


### PR DESCRIPTION
… process definition exists with null name