### PR TITLE
Changed formio evaluator template expressions

### DIFF
--- a/projects/valtimo/components/src/lib/components/form-io/form-io.component.ts
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io.component.ts
@@ -28,7 +28,7 @@ import {
 import {FormioSubmission, ValtimoFormioOptions} from '../../models';
 import {ValtimoModalService} from '../../services/valtimo-modal.service';
 import {UserProviderService} from '@valtimo/security';
-import {Formio, FormioComponent as FormIoSourceComponent} from '@formio/angular';
+import {Formio, FormioComponent as FormIoSourceComponent, FormioUtils} from '@formio/angular';
 import {FormioRefreshValue} from '@formio/angular/formio.common';
 import jwt_decode from 'jwt-decode';
 import {NGXLogger} from 'ngx-logger';
@@ -119,6 +119,10 @@ export class FormioComponent implements OnInit, OnChanges, OnDestroy {
   ) {}
 
   public ngOnInit(): void {
+
+    FormioUtils.Evaluator.templateSettings.escape = /\{{2,3}([\s\S]+?)\}{2,3}/g
+    FormioUtils.Evaluator.templateSettings.interpolate = /\[\[([\s\S]+?)\]\]/g
+
     this.openRouteSubscription();
     this.errors$.next([]);
     this.setInitialToken();

--- a/projects/valtimo/components/src/lib/components/form-io/form-io.component.ts
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io.component.ts
@@ -120,8 +120,8 @@ export class FormioComponent implements OnInit, OnChanges, OnDestroy {
 
   public ngOnInit(): void {
 
-    FormioUtils.Evaluator.templateSettings.escape = /\{{2,3}([\s\S]+?)\}{2,3}/g
-    FormioUtils.Evaluator.templateSettings.interpolate = /\[\[([\s\S]+?)\]\]/g
+    FormioUtils.Evaluator.templateSettings.escape = /\{{2,3}([\s\S]+?)\}{2,3}/g;
+    FormioUtils.Evaluator.templateSettings.interpolate = /\[\[([\s\S]+?)\]\]/g;
 
     this.openRouteSubscription();
     this.errors$.next([]);


### PR DESCRIPTION
Changed formio evaluator template expressions to guide users to using the escape type, which is safer when including data.