### PR TITLE
Updated the Form.io template pattern

### DIFF
--- a/projects/valtimo/components/src/lib/components/form-io/form-io.component.ts
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io.component.ts
@@ -126,7 +126,7 @@ export class FormioComponent implements OnInit, OnChanges, OnDestroy {
 
   public ngOnInit(): void {
     FormioUtils.Evaluator.templateSettings.escape = /\{{2,3}([\s\S]+?)\}{2,3}/g;
-    FormioUtils.Evaluator.templateSettings.interpolate = /\[\[([\s\S]+?)\]\]/g;
+    FormioUtils.Evaluator.templateSettings.interpolate = /\{([\s\S]+?)\}/g;
 
     this.openRouteSubscription();
     this.errors$.next([]);


### PR DESCRIPTION
Updated the Form.io template pattern so that two curly braces are used to escape and one is used for interpolation. (This is needed because due to an oddity in FormIO, the interpolation pattern needs to match the escape patterns as well, and we need to support two curly brackets for escaping due to backwards compatibility.)