### PR TITLE
- add handleActionOpenChange function to track opened Action

### DIFF
--- a/projects/valtimo/components/src/lib/components/carbon-list/carbon-list.component.html
+++ b/projects/valtimo/components/src/lib/components/carbon-list/carbon-list.component.html
@@ -99,14 +99,20 @@
 </ng-template>
 
 <ng-template #actionsMenuTemplate let-data="data">
-  <cds-overflow-menu (click)="$event.stopPropagation()">
+  <cds-overflow-menu
+    [open]="currentOpenActionId === data.item.id"
+    (openChange)="handleActionOpenChange(data.item.id, $event)"
+    [flip]="true"
+    [offset]="{x: 0, y: 50}"
+    placement="bottom"
+    (click)="$event.stopPropagation()"
+  >
     <cds-overflow-menu-option
       *ngFor="let action of data.actions"
       [type]="action.type"
       (selected)="action.callback(data.item)"
     >
       <i *ngIf="!!action.iconClass" [ngClass]="action.iconClass"></i>
-
       {{ action.label | translate }}
     </cds-overflow-menu-option>
   </cds-overflow-menu>

--- a/projects/valtimo/components/src/lib/components/carbon-list/carbon-list.component.ts
+++ b/projects/valtimo/components/src/lib/components/carbon-list/carbon-list.component.ts
@@ -18,7 +18,6 @@ import {
   ChangeDetectionStrategy,
   Component,
   EventEmitter,
-  HostBinding,
   Input,
   OnDestroy,
   OnInit,
@@ -94,6 +93,8 @@ export class CarbonListComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly _items$ = new BehaviorSubject<CarbonListItem[]>([]);
   private _items: CarbonListItem[];
   public items$ = new BehaviorSubject<TableItem[][]>([]);
+  public currentOpenActionId: string | null = null;
+
   @Input() set items(value: CarbonListItem[]) {
     this._items = value;
     this._items$.next(value);
@@ -587,5 +588,13 @@ export class CarbonListComponent implements OnInit, AfterViewInit, OnDestroy {
     temp[index1] = temp.splice(index2, 1, temp[index1])[0];
 
     return temp;
+  }
+
+  public handleActionOpenChange(actionId: string, isOpen: boolean) {
+    if (isOpen) {
+      this.currentOpenActionId = actionId;
+    } else if (this.currentOpenActionId === actionId) {
+      this.currentOpenActionId = null;
+    }
   }
 }

--- a/projects/valtimo/components/src/lib/components/carbon-list/carbon-list.component.ts
+++ b/projects/valtimo/components/src/lib/components/carbon-list/carbon-list.component.ts
@@ -590,7 +590,7 @@ export class CarbonListComponent implements OnInit, AfterViewInit, OnDestroy {
     return temp;
   }
 
-  public handleActionOpenChange(actionId: string, isOpen: boolean) {
+  public handleActionOpenChange(actionId: string, isOpen: boolean): void {
     if (isOpen) {
       this.currentOpenActionId = actionId;
     } else if (this.currentOpenActionId === actionId) {


### PR DESCRIPTION
Fixed unwanted behaviour when opening the action menu in a valtimo carbon list

Items fixed:
- previous action menu wont close when selection another one
- menu placement falls partially out of view

Behaviour before fix:

<img width="774" alt="Screenshot 2024-04-02 at 16 15 43" src="https://github.com/valtimo-platform/valtimo-frontend-libraries/assets/153727182/77964499-359f-4679-814c-e0eb4d550435">
