### PR TITLE
Feature/remove widget tag from carbon list

### DIFF
--- a/projects/valtimo/decision/src/lib/decision-list/decision-list.component.html
+++ b/projects/valtimo/decision/src/lib/decision-list/decision-list.component.html
@@ -16,21 +16,19 @@
 
 <ng-container *ngIf="decisionsLatestVersions$ | async as decisions">
   <ng-container *ngIf="(loading$ | async) === false">
-    <valtimo-widget>
-      <valtimo-carbon-list
-        [items]="decisions"
-        [fields]="fields"
-        (rowClicked)="viewDecisionTable($event)"
-        [header]="false"
-        [isSearchable]="true"
-      >
-        <ng-container carbonToolbarContent>
-          <button cdsButton="primary" (click)="this.deploy.openModal()">
-            {{ 'Upload' | translate }}
-          </button>
-        </ng-container>
-      </valtimo-carbon-list>
-    </valtimo-widget>
+    <valtimo-carbon-list
+      [items]="decisions"
+      [fields]="fields"
+      (rowClicked)="viewDecisionTable($event)"
+      [header]="false"
+      [isSearchable]="true"
+    >
+      <ng-container carbonToolbarContent>
+        <button cdsButton="primary" (click)="this.deploy.openModal()">
+          {{ 'Upload' | translate }}
+        </button>
+      </ng-container>
+    </valtimo-carbon-list>
   </ng-container>
 </ng-container>
 

--- a/projects/valtimo/object/src/lib/components/object-list/object-list.component.html
+++ b/projects/valtimo/object/src/lib/components/object-list/object-list.component.html
@@ -61,24 +61,22 @@
 </ng-template>
 
 <ng-template #list let-obs="obs">
-  <valtimo-widget>
-    <valtimo-carbon-list
-      [items]="obs.objectConfiguration"
-      [fields]="obs.fields"
-      [header]="false"
-      [pagination]="obs.pagination"
-      paginationIdentifier="objectConfigurationList"
-      (paginationClicked)="paginationClicked($event)"
-      (paginationSet)="paginationSet($event)"
-      (rowClicked)="redirectToDetails($event)"
-    >
-      <ng-container carbonToolbarContent>
-        <button cdsButton="primary" (click)="openModal()">
-          {{ 'object.createObject' | translate }}
-        </button>
-      </ng-container>
-    </valtimo-carbon-list>
-  </valtimo-widget>
+  <valtimo-carbon-list
+    [items]="obs.objectConfiguration"
+    [fields]="obs.fields"
+    [header]="false"
+    [pagination]="obs.pagination"
+    paginationIdentifier="objectConfigurationList"
+    (paginationClicked)="paginationClicked($event)"
+    (paginationSet)="paginationSet($event)"
+    (rowClicked)="redirectToDetails($event)"
+  >
+    <ng-container carbonToolbarContent>
+      <button cdsButton="primary" (click)="openModal()">
+        {{ 'object.createObject' | translate }}
+      </button>
+    </ng-container>
+  </valtimo-carbon-list>
 </ng-template>
 
 <ng-template #createNewModal>


### PR DESCRIPTION
Removed the valtimo-widget tag what causes to draw a white border around the carbon list.
This results in a unwanted appearance when switch to darkmode