### PR TITLE
Overflow menu fix

### DIFF
--- a/projects/valtimo/components/src/lib/components/carbon-list/carbon-list.component.html
+++ b/projects/valtimo/components/src/lib/components/carbon-list/carbon-list.component.html
@@ -100,8 +100,8 @@
 
 <ng-template #actionsMenuTemplate let-data="data">
   <cds-overflow-menu
-    [open]="currentOpenActionId === data.item.id"
-    (openChange)="handleActionOpenChange(data.item.id, $event)"
+    [open]="currentOpenActionId === data.item"
+    (openChange)="handleActionOpenChange(data.item, $event)"
     [flip]="true"
     [offset]="{x: 0, y: 50}"
     placement="bottom"


### PR DESCRIPTION
Using data.item instead of data.item.id for targeting the right overflow menu id so the overflow menu displays on all carbon lists correct.