### PR TITLE
96817: Exporting permissions for a single role

### DIFF
--- a/projects/valtimo/access-control-management/src/lib/components/editor/access-control-editor.component.html
+++ b/projects/valtimo/access-control-management/src/lib/components/editor/access-control-editor.component.html
@@ -36,7 +36,7 @@
 
         <cds-overflow-menu-option
           [disabled]="obs.moreDisabled"
-          (selected)="exportPermissions(obs.model)"
+          (selected)="exportPermissions()"
           >{{ 'interface.export' | translate }}</cds-overflow-menu-option
         >
 

--- a/projects/valtimo/access-control-management/src/lib/components/editor/access-control-editor.component.ts
+++ b/projects/valtimo/access-control-management/src/lib/components/editor/access-control-editor.component.ts
@@ -141,12 +141,8 @@ export class AccessControlEditorComponent implements OnInit, OnDestroy {
     });
   }
 
-  public exportPermissions(model: EditorModel): void {
-    this.accessControlExportService.downloadJson(
-      JSON.parse(model.value),
-      'separate',
-      this._roleKey
-    );
+  public exportPermissions(): void {
+    this.accessControlExportService.exportRoles({type: 'separate', roleKeys: [this._roleKey]}).subscribe()
   }
 
   private openRoleKeySubscription(): void {

--- a/projects/valtimo/access-control-management/src/lib/services/access-control-export.service.ts
+++ b/projects/valtimo/access-control-management/src/lib/services/access-control-export.service.ts
@@ -49,7 +49,7 @@ export class AccessControlExportService {
     );
   }
 
-  public downloadJson(permissions: Array<object>, type: RoleExport, roleKey?: string): void {
+  private downloadJson(permissions: Array<object>, type: RoleExport, roleKey?: string): void {
     const sJson = JSON.stringify({permissions}, null, 2);
     const element = document.createElement('a');
     element.setAttribute('href', 'data:text/json;charset=UTF-8,' + encodeURIComponent(sJson));


### PR DESCRIPTION
Fixed: 96817 Exporting permissions for a single role results in a file that can't be imported