### PR TITLE
Exposed JWT token to form.io

### DIFF
--- a/projects/valtimo/components/src/lib/components/form-io/form-io.component.ts
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io.component.ts
@@ -135,6 +135,9 @@ export class FormioComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   public ngOnInit(): void {
+    Formio.setProjectUrl(location.origin);
+    Formio.authUrl = location.origin;
+
     this.openRouteSubscription();
     this.errors$.next([]);
     this.setInitialToken();
@@ -213,6 +216,7 @@ export class FormioComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private setToken(token: string): void {
+    Formio.setUser(jwtDecode(token));
     Formio.setToken(token);
     localStorage.setItem(this._FORMIO_TOKEN_LOCAL_STORAGE_KEY, token);
     this.setTimerForTokenRefresh(token);


### PR DESCRIPTION
TP #110428

- Set Formio's `projectUrl` and `authUrl to the current origin, so that api.form.io no longer is used as a default.
- Set the user in Formio so that the `/current` endpoint is no longer called.