### PR TITLE
- Set Formio's `projectUrl` and `authUrl to the current origin, so th…

### DIFF
--- a/projects/valtimo/components/src/lib/components/form-io/form-io.component.ts
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io.component.ts
@@ -111,6 +111,9 @@ export class FormioComponent implements OnInit, OnChanges, OnDestroy {
   ) {}
 
   public ngOnInit() {
+    Formio.setProjectUrl(location.origin);
+    Formio.authUrl = location.origin;
+
     this.openRouteSubscription();
     this.errors$.next([]);
     this.setInitialToken();
@@ -190,6 +193,7 @@ export class FormioComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private setToken(token: string): void {
+    Formio.setUser(jwt_decode(token));
     Formio.setToken(token);
     localStorage.setItem('formioToken', token);
     this.setTimerForTokenRefresh(token);


### PR DESCRIPTION
…at api.form.io no longer is used as a default.

- Set the user in Formio so that the `/current` endpoint is no longer called.