### PR TITLE
feature/93310-besluiten-api-create-besluit-node16

### DIFF
--- a/projects/valtimo/form-link/src/lib/services/process-link.service.ts
+++ b/projects/valtimo/form-link/src/lib/services/process-link.service.ts
@@ -81,6 +81,15 @@ export class ProcessLinkService {
       | FormFlowProcessLinkCreateRequestDto
       | PluginProcessLinkCreateDto
   ): Observable<null> {
+    const pluginProcessLinkCreateRequest = saveProcessLinkRequest as PluginProcessLinkCreateDto;
+    if (pluginProcessLinkCreateRequest.actionProperties) {
+      Object.keys(pluginProcessLinkCreateRequest.actionProperties).forEach(key => {
+        if (pluginProcessLinkCreateRequest.actionProperties[key] === '') {
+          pluginProcessLinkCreateRequest.actionProperties[key] = null;
+        }
+      });
+    }
+
     return this.http.post<null>(
       `${this.VALTIMO_ENDPOINT_URI}v1/process-link`,
       saveProcessLinkRequest


### PR DESCRIPTION
Bug fix, submitting empty string while creating a plugin action. It now submits null instead of empty string. 