### PR TITLE
bugfix preventing double slash

### DIFF
--- a/projects/valtimo/dossier/src/lib/components/dossier-detail/tab/documenten-api-documents/documenten-api-documents.component.ts
+++ b/projects/valtimo/dossier/src/lib/components/dossier-detail/tab/documenten-api-documents/documenten-api-documents.component.ts
@@ -123,7 +123,7 @@ export class DossierDetailTabDocumentenApiDocumentsComponent implements OnInit {
       this.downloadingFileIndexes$.next([...indexes, index]);
 
       const finished$: Observable<null> = this.downloadService.downloadFile(
-        `${this.valtimoEndpointUri}/v1/documenten-api/${relatedFile.pluginConfigurationId}/files/${relatedFile.fileId}/download`,
+        `${this.valtimoEndpointUri}v1/documenten-api/${relatedFile.pluginConfigurationId}/files/${relatedFile.fileId}/download`,
         relatedFile.fileName
       );
 


### PR DESCRIPTION
There is already a slash in the valtimoEndpointUri so it is not required before the v1