### PR TITLE
story/116399 case admin carbon theme bug

### DIFF
--- a/projects/valtimo/dossier-management/src/lib/components/dossier-management-detail-container/dossier-management-detail-container.component.html
+++ b/projects/valtimo/dossier-management/src/lib/components/dossier-management-detail-container/dossier-management-detail-container.component.html
@@ -22,11 +22,7 @@
   class="dossier-management-detail-container"
 >
   <valtimo-documenten-api></valtimo-documenten-api>
-  <cds-tabs
-    class="dossier-management-tabs"
-    type="contained"
-    [attr.data-carbon-theme]="CARBON_THEME"
-  >
+  <cds-tabs class="dossier-management-tabs" type="contained">
     <cds-tab
       class="no-padding-left-right no-padding-top-bottom"
       [active]="obs.currentTab === TabEnum.DOCUMENT"


### PR DESCRIPTION
Removed carbon-theme attribute from tabs to keep the tab theme (and underlying components) in line with the selected root theme.