### PR TITLE
#109854 form flow when going back in form flow fields should not be required

### DIFF
--- a/projects/valtimo/components/src/lib/components/form-io/form-io.component.html
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io.component.html
@@ -46,5 +46,6 @@
     (prevPage)="prevPage()"
     (ready)="formReady($event)"
     (submit)="onSubmit($event)"
+    (customEvent)="onCustomEvent($event)"
   ></formio>
 </div>

--- a/projects/valtimo/components/src/lib/components/form-io/form-io.component.ts
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io.component.ts
@@ -73,6 +73,7 @@ export class FormioComponent implements OnInit, OnChanges, OnDestroy {
   @Output() submit = new EventEmitter<any>();
   // eslint-disable-next-line @angular-eslint/no-output-native
   @Output() change = new EventEmitter<any>();
+  @Output() event = new EventEmitter<any>();
 
   @HostListener('window:beforeunload', ['$event'])
   private handleBeforeUnload() {
@@ -188,6 +189,10 @@ export class FormioComponent implements OnInit, OnChanges, OnDestroy {
 
   public onChange(object: any): void {
     this.change.emit(object);
+  }
+
+  public onCustomEvent(event: any): void {
+    this.event.emit(event);
   }
 
   public nextPage(): void {

--- a/projects/valtimo/process-link/src/lib/components/form-flow/form-flow.component.html
+++ b/projects/valtimo/process-link/src/lib/components/form-flow/form-flow.component.html
@@ -21,6 +21,7 @@
       [form]="formDefinition"
       (submit)="onSubmit($event)"
       (change)="onChange($event)"
+      (event)="onEvent($event)"
       [options]="formioOptions"
     ></valtimo-form-io>
   </div>

--- a/projects/valtimo/process-link/src/lib/components/form-flow/form-flow.component.ts
+++ b/projects/valtimo/process-link/src/lib/components/form-flow/form-flow.component.ts
@@ -86,13 +86,13 @@ export class FormFlowComponent implements OnInit {
           }
         );
     } else if (submission.data['back']) {
-      this.formFlowService.back(this.formFlowInstanceId, submission.data).subscribe(
-        (result: FormFlowInstance) => this.handleFormFlowStep(result),
-        errors => {
-          this.form?.showErrors(errors);
-          this.enable();
-        }
-      );
+      this.back(submission.data);
+    }
+  }
+
+  public onEvent(submission: any): void {
+    if (submission.data['back'] || submission.type == 'back') {
+      this.back(submission.data);
     }
   }
 
@@ -112,6 +112,16 @@ export class FormFlowComponent implements OnInit {
       .subscribe((result: FormFlowInstance) => {
         this.handleFormFlowStep(result);
       });
+  }
+
+  private back(submissionData: any): void {
+    this.formFlowService.back(this.formFlowInstanceId, submissionData).subscribe(
+      (result: FormFlowInstance) => this.handleFormFlowStep(result),
+      errors => {
+        this.form?.showErrors(errors);
+        this.enable();
+      }
+    );
   }
 
   private handleFormFlowStep(formFlowInstance: FormFlowInstance) {


### PR DESCRIPTION
Going back in a form flow can now also be configured in a way that doesn't require the form to be valid. Like this:

![Screenshot 2024-08-20 at 13 58 38](https://github.com/user-attachments/assets/9ad57d6f-fd41-4fc7-8bc5-1771d7b7160c)
