### PR TITLE
Case list actions speed improvement

### DIFF
--- a/projects/valtimo/document/src/lib/services/document.service.ts
+++ b/projects/valtimo/document/src/lib/services/document.service.ts
@@ -297,6 +297,15 @@ export class DocumentService {
     );
   }
 
+  public findProcessDocumentDefinitionsByCanInitializeDocument(
+    documentDefinitionName: string,
+    canInitializeDocument: boolean
+  ): Observable<ProcessDocumentDefinition[]> {
+    return this.http.get<ProcessDocumentDefinition[]>(
+      `${this.valtimoEndpointUri}v1/process-document/definition/document/${documentDefinitionName}?canInitializeDocument=${canInitializeDocument}`
+    );
+  }
+
   public findProcessDocumentDefinitionsByVersion(
     documentDefinitionName: string,
     version: number

--- a/projects/valtimo/dossier/src/lib/components/dossier-list-actions/dossier-list-actions.component.ts
+++ b/projects/valtimo/dossier/src/lib/components/dossier-list-actions/dossier-list-actions.component.ts
@@ -43,7 +43,7 @@ export class DossierListActionsComponent implements OnInit {
     switchMap(documentDefinitionName =>
       combineLatest([
         documentDefinitionName
-          ? this.documentService.findProcessDocumentDefinitionsByStartableByUser(documentDefinitionName, true)
+          ? this.documentService.findProcessDocumentDefinitionsByCanInitializeDocument(documentDefinitionName, true)
           : of([]),
         this._loading$,
       ])

--- a/projects/valtimo/dossier/src/lib/components/dossier-list-actions/dossier-list-actions.component.ts
+++ b/projects/valtimo/dossier/src/lib/components/dossier-list-actions/dossier-list-actions.component.ts
@@ -43,7 +43,7 @@ export class DossierListActionsComponent implements OnInit {
     switchMap(documentDefinitionName =>
       combineLatest([
         documentDefinitionName
-          ? this.documentService.findProcessDocumentDefinitions(documentDefinitionName)
+          ? this.documentService.findProcessDocumentDefinitionsByStartableByUser(documentDefinitionName, true)
           : of([]),
         this._loading$,
       ])


### PR DESCRIPTION
Applied a fix to improve speed of list actions, only include process definitions linked to the case/document which can initialize/create a case/document