### PR TITLE
fix: fix documenten api metadata status validation

### DIFF
--- a/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-metadata-modal/documenten-api-metadata-modal.component.ts
+++ b/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-metadata-modal/documenten-api-metadata-modal.component.ts
@@ -526,6 +526,9 @@ export class DocumentenApiMetadataModalComponent implements OnInit, OnChanges, O
       else if (ontvangstdatum) this.additionalDocumentDate$.next('received');
       else this.additionalDocumentDate$.next('neither');
 
+      const prefillStatus = this.status || status;
+      const validPrefillStatus = this.STATUSES.includes(prefillStatus) ? prefillStatus : '';
+
       this.documentenApiMetadataForm.patchValue({
         bestandsnaam: this.filename || bestandsnaam,
         titel: this.documentTitle || titel,
@@ -533,7 +536,7 @@ export class DocumentenApiMetadataModalComponent implements OnInit, OnChanges, O
         beschrijving: this.description || beschrijving,
         taal: this.language || taal,
         informatieobjecttype: this.documentType || informatieobjecttype,
-        status: this.status || status,
+        status: validPrefillStatus,
         vertrouwelijkheidaanduiding: this.confidentialityLevel || vertrouwelijkheidaanduiding,
         creatiedatum,
         ontvangstdatum,


### PR DESCRIPTION
closes https://ritense.tpondemand.com/entity/121242-fe-documenten-api-metadata-modal-validation