### PR TITLE
Fixed the timer drift that happens on the session-expire timer.

### DIFF
--- a/projects/valtimo/keycloak/src/lib/services/keycloak-user.service.ts
+++ b/projects/valtimo/keycloak/src/lib/services/keycloak-user.service.ts
@@ -118,7 +118,7 @@ export class KeycloakUserService implements UserService, OnDestroy {
     );
   }
 
-  private get expiryTimeMs() {
+  private get _expiryTimeMs() {
     return this._tokenExp - Date.now() - 1000;
   }
 
@@ -141,9 +141,9 @@ export class KeycloakUserService implements UserService, OnDestroy {
     this.expiryTimerSubscription = timer(0, 1000)
       .pipe(
         switchMap(() => {
-          if (this.expiryTimeMs <= this.FIVE_MINUTES_MS) {
+          if (this._expiryTimeMs <= this.FIVE_MINUTES_MS) {
             this._counter = new Date(0, 0, 0, 0, 0, 0);
-            this._counter.setSeconds(this.expiryTimeMs / 1000);
+            this._counter.setSeconds(this._expiryTimeMs / 1000);
           }
 
           return combineLatest([
@@ -161,7 +161,7 @@ export class KeycloakUserService implements UserService, OnDestroy {
         this.promptService.identifier$.pipe(take(1)).subscribe(identifier => {
           if (
             (!promptVisible || identifier !== this.EXPIRE_TOKEN_CONFIRMATION) &&
-            this.expiryTimeMs <= this.FIVE_MINUTES_MS
+            this._expiryTimeMs <= this.FIVE_MINUTES_MS
           ) {
             this.openConfirmationPrompt(headerText, bodyText, cancelButtonText, confirmButtonText);
           }
@@ -171,7 +171,7 @@ export class KeycloakUserService implements UserService, OnDestroy {
           }
         });
 
-        if (this.expiryTimeMs < 2000) {
+        if (this._expiryTimeMs < 2000) {
           this.saveUrl();
           this.logout();
         }


### PR DESCRIPTION
Browsers [are not guaranteed](https://stackoverflow.com/questions/985670/will-setinterval-drift) to execute a timer after the specified amount of time. This means that if you manually subtract a second at any timer interval of a second, the timer will drift. (This can easily be tested by going to the browser developer tools, in the Sources tab, and hitting the pause button.) This is true when the browser tab is active (as other things might occupy the thread when it's time to execute), but even more so when a tab is inactive, because the browser will save resources and slow it down on purpose. This will cause the timer to be heavily out of sync with the actual token expiration time.

To fix this, we now recalculate the time left before expiry, instead of subtracting a second.

<sup>(Given that the timer runs once a second, the timer might still be off by a few tens of seconds, but never more than one second. In vanilla JavaScript I can fix that [fairly easily](https://stackoverflow.com/a/29972322), but I don't have the slightest clue how to achieve that in RSJX.)</sup>