### PR TITLE
Add notification when no process is linked to task

### DIFF
--- a/projects/valtimo/config/assets/core/de.json
+++ b/projects/valtimo/config/assets/core/de.json
@@ -150,7 +150,8 @@
       "noFiles": "Für diesen Fall wurden keine Dateien gefunden."
     },
     "startSubProcess": "Starten",
-    "noLinkedProcessNotification": "Es ist kein Startformular verknüpft",
+    "noLinkedStartProcessNotification": "Es ist kein Startformular verknüpft",
+    "noLinkedProcessNotification": "Es ist kein formular verknüpft",
     "configure": "Konfigurieren",
     "claimAssigneeCase": "Anmaßen",
     "deleteConfirmation": {

--- a/projects/valtimo/config/assets/core/en.json
+++ b/projects/valtimo/config/assets/core/en.json
@@ -150,7 +150,8 @@
       "noFiles": "No files found for this case."
     },
     "startSubProcess": "Start",
-    "noLinkedProcessNotification": "There is no start form linked",
+    "noLinkedStartProcessNotification": "There is no start form linked",
+    "noLinkedProcessNotification": "There is no form linked",
     "configure": "Configure",
     "claimAssigneeCase": "Claim",
     "deleteConfirmation": {

--- a/projects/valtimo/config/assets/core/nl.json
+++ b/projects/valtimo/config/assets/core/nl.json
@@ -150,7 +150,8 @@
       "noFiles": "Geen bestanden gevonden voor deze zaak."
     },
     "startSubProcess": "Start",
-    "noLinkedProcessNotification": "Er is geen startformulier gekoppeld",
+    "noLinkedStartProcessNotification": "Er is geen startformulier gekoppeld",
+    "noLinkedProcessNotification": "Er is geen formulier gekoppeld",
     "configure": "Configureer",
     "claimAssigneeCase": "Claimen",
     "deleteConfirmation": {

--- a/projects/valtimo/dossier/src/lib/components/dossier-detail/dossier-detail.component.html
+++ b/projects/valtimo/dossier/src/lib/components/dossier-detail/dossier-detail.component.html
@@ -111,6 +111,7 @@
   </div>
 
   <valtimo-dossier-supporting-process-start-modal
+    [isAdmin]="isAdmin$ | async"
     (formSubmit)="tabLoader.refreshView()"
     #supportingProcessStartModal
   ></valtimo-dossier-supporting-process-start-modal>

--- a/projects/valtimo/dossier/src/lib/components/dossier-list-actions/dossier-list-actions.component.ts
+++ b/projects/valtimo/dossier/src/lib/components/dossier-list-actions/dossier-list-actions.component.ts
@@ -110,19 +110,15 @@ export class DossierListActionsComponent implements OnInit {
     this.notificationService.showActionable({
       type: 'warning',
       lowContrast: true,
-      title: this.translateService.instant('dossier.noLinkedProcessNotification'),
+      title: this.translateService.instant('dossier.noLinkedStartProcessNotification'),
       actions: [
         {
           text: this.translateService.instant('dossier.configure'),
-          click: () => this.onConfigureClick(),
+          click: () => this.router.navigate(['/process-links']),
         },
       ],
       duration: CARBON_CONSTANTS.notificationDuration,
     });
-  }
-
-  private onConfigureClick(): void {
-    this.router.navigate(['/process-links']);
   }
 
   private showStartProcessModal(): void {

--- a/projects/valtimo/dossier/src/lib/components/dossier-supporting-process-start-modal/dossier-supporting-process-start-modal.component.html
+++ b/projects/valtimo/dossier/src/lib/components/dossier-supporting-process-start-modal/dossier-supporting-process-start-modal.component.html
@@ -54,7 +54,7 @@
     <div body *ngIf="!obs.formDefinition && !obs.formFlowInstanceId">
       <div class="bg-warning text-black mb-0 p-3 text-center">
         {{
-          (isAdmin$ | async)
+          isAdmin
             ? ('formManagement.noFormDefinitionFoundAdmin' | translate)
             : ('formManagement.noFormDefinitionFoundUser' | translate)
         }}

--- a/projects/valtimo/dossier/src/lib/components/dossier-supporting-process-start-modal/dossier-supporting-process-start-modal.component.ts
+++ b/projects/valtimo/dossier/src/lib/components/dossier-supporting-process-start-modal/dossier-supporting-process-start-modal.component.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import {Component, EventEmitter, Output, ViewChild, ViewEncapsulation} from '@angular/core';
+import {Component, EventEmitter, Input, Output, ViewChild, ViewEncapsulation} from '@angular/core';
+import {Router} from '@angular/router';
 import {FormioBeforeSubmit, FormioForm} from '@formio/angular';
 import {
   FormioComponent,
@@ -23,13 +23,11 @@ import {
   ModalComponent,
   ValtimoFormioOptions,
 } from '@valtimo/components';
-import {Router} from '@angular/router';
-import {ProcessService} from '@valtimo/process';
 import {ProcessDocumentDefinition} from '@valtimo/document';
+import {ProcessService} from '@valtimo/process';
 import {FormSubmissionResult, ProcessLinkService} from '@valtimo/process-link';
-import {BehaviorSubject, combineLatest, Observable, switchMap} from 'rxjs';
-import {map, take} from 'rxjs/operators';
-import {UserProviderService} from '@valtimo/security';
+import {BehaviorSubject, combineLatest, switchMap} from 'rxjs';
+import {take} from 'rxjs/operators';
 
 @Component({
   selector: 'valtimo-dossier-supporting-process-start-modal',
@@ -41,6 +39,7 @@ export class DossierSupportingProcessStartModalComponent {
   @ViewChild('form', {static: false}) form: FormioComponent;
   @ViewChild('supportingProcessStartModal', {static: false}) modal: ModalComponent;
 
+  @Input() isAdmin: boolean;
   @Output() formSubmit = new EventEmitter();
 
   public readonly processDefinitionKey$ = new BehaviorSubject<string>('');
@@ -55,15 +54,10 @@ export class DossierSupportingProcessStartModalComponent {
   public readonly formFlowInstanceId$ = new BehaviorSubject<string>(undefined);
   public readonly documentId$ = new BehaviorSubject<string>(undefined);
 
-  public readonly isAdmin$: Observable<boolean> = this.userProviderService
-    .getUserSubject()
-    .pipe(map(userIdentity => userIdentity?.roles?.includes('ROLE_ADMIN')));
-
   constructor(
     private readonly router: Router,
     private readonly processService: ProcessService,
-    private readonly processLinkService: ProcessLinkService,
-    private readonly userProviderService: UserProviderService
+    private readonly processLinkService: ProcessLinkService
   ) {}
 
   private loadProcessLink(): void {

--- a/projects/valtimo/task/src/lib/components/task-detail-content/task-detail-content.component.html
+++ b/projects/valtimo/task/src/lib/components/task-detail-content/task-detail-content.component.html
@@ -77,15 +77,4 @@
   <div class="m-2">
     <ng-template #formViewModelComponent></ng-template>
   </div>
-
-  <div *ngIf="!obs.formDefinition && !obs.formFlowInstanceId" class="mb-0 p-3 text-center">
-    <button
-      class="btn btn-secondary btn-space"
-      type="button"
-      (click)="gotoProcessLinkScreen()"
-      id="process-link-button"
-    >
-      {{ 'formManagement.gotoProcessLinksButton' | translate }}
-    </button>
-  </div>
 </ng-container>

--- a/projects/valtimo/task/src/lib/components/task-detail-content/task-detail-content.component.ts
+++ b/projects/valtimo/task/src/lib/components/task-detail-content/task-detail-content.component.ts
@@ -48,7 +48,8 @@ import {
   FormFlowComponent,
   FormSubmissionResult,
   ProcessLinkModule,
-  ProcessLinkService, UrlResolverService,
+  ProcessLinkService,
+  UrlResolverService,
 } from '@valtimo/process-link';
 import {IconService} from 'carbon-components-angular';
 import {NGXLogger} from 'ngx-logger';
@@ -131,7 +132,7 @@ export class TaskDetailContentComponent implements OnInit, OnDestroy {
     private readonly toastr: ToastrService,
     private readonly translateService: TranslateService,
     @Optional() @Inject(FORM_VIEW_MODEL_TOKEN) private readonly formViewModel: FormViewModel,
-    private readonly urlResolverService: UrlResolverService,
+    private readonly urlResolverService: UrlResolverService
   ) {
     this.intermediateSaveEnabled = !!this.configService.featureToggles?.enableIntermediateSave;
 
@@ -220,12 +221,6 @@ export class TaskDetailContentComponent implements OnInit, OnDestroy {
     });
   }
 
-  public gotoProcessLinkScreen(): void {
-    this.closeModalEvent.emit();
-    if (this.formFlow) this.formFlow.saveData();
-    this.router.navigate(['process-links']);
-  }
-
   private getCurrentProgress(formViewModelComponentRef?: ComponentRef<any>): void {
     this.taskInstanceId$
       .pipe(
@@ -272,21 +267,20 @@ export class TaskDetailContentComponent implements OnInit, OnDestroy {
             case 'url':
               this._taskProcessLinkType$.next('url');
               this._processLinkId$.next(res.processLinkId);
-              combineLatest([
-                this.processLinkService.getVariables(),
-                this.task$
-              ]).pipe(take(1))
+              combineLatest([this.processLinkService.getVariables(), this.task$])
+                .pipe(take(1))
                 .subscribe(([variables, task]) => {
-                  let url = this.urlResolverService.resolveUrlVariables(res.properties.url, variables.variables);
+                  let url = this.urlResolverService.resolveUrlVariables(
+                    res.properties.url,
+                    variables.variables
+                  );
                   window.open(url, '_blank').focus();
-                  this.processLinkService.submitURLProcessLink(
-                    res.processLinkId,
-                    task.businessKey,
-                    task.id
-                  ).subscribe(() => {
-                    this.completeTask(task);
-                  });
-                })
+                  this.processLinkService
+                    .submitURLProcessLink(res.processLinkId, task.businessKey, task.id)
+                    .subscribe(() => {
+                      this.completeTask(task);
+                    });
+                });
               break;
           }
 
@@ -294,6 +288,7 @@ export class TaskDetailContentComponent implements OnInit, OnDestroy {
         }
       },
       error: _ => {
+        console.log({_});
         this.loading$.next(false);
       },
     });

--- a/projects/valtimo/task/src/lib/services/task.service.ts
+++ b/projects/valtimo/task/src/lib/services/task.service.ts
@@ -15,7 +15,7 @@
  */
 
 import {Injectable} from '@angular/core';
-import {HttpClient, HttpParams, HttpResponse} from '@angular/common/http';
+import {HttpClient, HttpHeaders, HttpParams, HttpResponse} from '@angular/common/http';
 import {Observable} from 'rxjs';
 import {
   AssigneeRequest,
@@ -131,9 +131,7 @@ export class TaskService extends BaseApiService {
   public getTaskProcessLink(taskId: string): Observable<TaskProcessLinkResult> {
     return this.httpClient.get<TaskProcessLinkResult>(
       this.getApiUrl(`/v2/process-link/task/${taskId}`),
-      {
-        headers: {[InterceptorSkip]: '404'},
-      }
+      {headers: new HttpHeaders().set(InterceptorSkip, '404')}
     );
   }
 


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue:

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->
**Relevant comments:**
> [[FE] 'Configure now' button shows while loading task form](https://ritense.tpondemand.com/entity/123092-fe-configure-now-button-shows-while)

> *PLEASE CHECK TRANSLATIONS*

> Notification when user is Admin:
> ![when-admin](https://github.com/user-attachments/assets/d65622dd-4092-4432-84bb-4f680c231e4a)

> Notification when user is not Admin:
>![when-user](https://github.com/user-attachments/assets/0afb3661-1caa-4e55-b8d2-70cad1ce0a55)


### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [ ] Release notes have been written for these changes.

Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
>

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable
