### PR TITLE
bugfix - invalid download uri

### DIFF
--- a/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-documents/documenten-api-documents.component.ts
+++ b/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-documents/documenten-api-documents.component.ts
@@ -417,7 +417,7 @@ export class DossierDetailTabDocumentenApiDocumentsComponent implements OnInit, 
 
   private downloadDocument(relatedFile: DocumentenApiRelatedFile, forceDownload: boolean): void {
     this.downloadService.downloadFile(
-      `${this.valtimoEndpointUri}/api/v1/documenten-api/${relatedFile.pluginConfigurationId}/files/${relatedFile.fileId}/download`,
+      `${this.valtimoEndpointUri}v1/documenten-api/${relatedFile.pluginConfigurationId}/files/${relatedFile.fileId}/download`,
       relatedFile.bestandsnaam ?? '',
       forceDownload
     );


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
The valtimoEndpointUrl already contains an api/ so currently the download uri contains /api//api/. Fixed the documenten-api-documents.component.ts so the extra api and / are removed

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [ ] Release notes have been written for these changes.

Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
>

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable
