### PR TITLE
bugfix - invalid download uri (#1251)

### DIFF
--- a/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-documents/documenten-api-documents.component.ts
+++ b/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-documents/documenten-api-documents.component.ts
@@ -417,7 +417,7 @@ export class DossierDetailTabDocumentenApiDocumentsComponent implements OnInit, 
 
   private downloadDocument(relatedFile: DocumentenApiRelatedFile, forceDownload: boolean): void {
     this.downloadService.downloadFile(
-      `${this.valtimoEndpointUri}/api/v1/documenten-api/${relatedFile.pluginConfigurationId}/files/${relatedFile.fileId}/download`,
+      `${this.valtimoEndpointUri}v1/documenten-api/${relatedFile.pluginConfigurationId}/files/${relatedFile.fileId}/download`,
       relatedFile.bestandsnaam ?? '',
       forceDownload
     );


### PR DESCRIPTION
The valtimoEndpointUri already contains an api/, so it should not be added

<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue:

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->
**Relevant comments:**
>

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [ ] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [ ] Release notes have been written for these changes.

Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
>

New features or changes that have been introduced have been documented.
- [ ] Yes
- [ ] Not applicable
