### PR TITLE
Add padding to notes textarea

### DIFF
--- a/projects/valtimo/dossier/src/lib/components/note-modal/note-modal.component.html
+++ b/projects/valtimo/dossier/src/lib/components/note-modal/note-modal.component.html
@@ -68,6 +68,7 @@
   <ng-container *ngIf="showForm$ | async">
     <v-form (valueChange)="formValueChange($event)">
       <v-input
+        class="notes-input"
         type="textarea"
         [margin]="true"
         [required]="true"

--- a/projects/valtimo/dossier/src/lib/components/note-modal/note-modal.component.scss
+++ b/projects/valtimo/dossier/src/lib/components/note-modal/note-modal.component.scss
@@ -25,3 +25,7 @@
 .add-note-title {
   justify-content: center;
 }
+
+::ng-deep .notes-input textarea {
+  padding: 8px;
+}


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue:

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->
**Relevant comments:**
> Add padding to textarea in Notes to make it more visible

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [ ] Release notes have been written for these changes.

Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
>

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable
