### PR TITLE
Add fix for ellipsis cutting one character short

### DIFF
--- a/projects/valtimo/components/src/lib/pipes/ellipsis.pipe.ts
+++ b/projects/valtimo/components/src/lib/pipes/ellipsis.pipe.ts
@@ -2,9 +2,9 @@ import {Pipe, PipeTransform} from '@angular/core';
 
 @Pipe({name: 'valtimoEllipsis', standalone: true})
 export class EllipsisPipe implements PipeTransform {
-  public transform(content: string, limit: number | null): string {
+  public transform(content: string, limit?: number | null): string {
     if (!limit) return content;
 
-    return content.substring(0, limit - 1) + (content.length > limit ? '...' : '');
+    return content.substring(0, limit) + (content.length > limit ? '...' : '');
   }
 }


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes

Link to the related Github issue:

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

**Relevant comments:**

> Fix comment for:  [[FE] Add ellipsis to field widget](https://ritense.tpondemand.com/entity/129861-fe-add-ellipsis-to-field-widget)

### Breaking changes

<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->

- [x] The contribution only contains changes that are not breaking.

### Documentation

<!-- Release notes should be available in the Valtimo documentation.  -->

- [ ] Release notes have been written for these changes.

Link to the pull request in the
[Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):

>

New features or changes that have been introduced have been documented.

- [ ] Yes
- [x] Not applicable
