### PR TITLE
story/fix-fvm-dropdown update fvm only when component was focused and blurred, and data was changed during that time

### DIFF
--- a/projects/valtimo/form-view-model/src/lib/components/form-view-model/form-view-model.component.html
+++ b/projects/valtimo/form-view-model/src/lib/components/form-view-model/form-view-model.component.html
@@ -46,6 +46,7 @@
     [refresh]="refreshForm"
     (submit)="onSubmit($event)"
     (change)="onChange($event)"
+    (focusin)="onFocus($event)"
     (focusout)="onBlur($event)"
     (nextPage)="onNextPage()"
     (prevPage)="onPreviousPage()"

--- a/projects/valtimo/form-view-model/src/lib/components/form-view-model/form-view-model.component.ts
+++ b/projects/valtimo/form-view-model/src/lib/components/form-view-model/form-view-model.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Component, EventEmitter, Input, OnInit, Output, ViewChild} from '@angular/core';
+import {Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild} from '@angular/core';
 import moment from 'moment';
 import {
   BehaviorSubject,
@@ -22,7 +22,7 @@ import {
   debounceTime,
   EMPTY, filter,
   Observable,
-  of, Subject,
+  of, Subject, Subscription,
   switchMap,
   take,
   tap, withLatestFrom,
@@ -52,7 +52,7 @@ moment.defaultFormat = 'DD MMM YYYY HH:mm';
   standalone: true,
   imports: [CommonModule, FormioModule],
 })
-export class FormViewModelComponent implements OnInit {
+export class FormViewModelComponent implements OnInit, OnDestroy {
   @ViewChild('formio') formio: FormioComponent;
 
   @Input() set options(optionsValue: any) {
@@ -153,6 +153,9 @@ export class FormViewModelComponent implements OnInit {
     })
   );
 
+  private focusSubscription: Subscription
+  private updateSubscription: Subscription
+
   constructor(
     private readonly viewModelService: ViewModelService,
     private readonly translateService: TranslateService,
@@ -166,7 +169,7 @@ export class FormViewModelComponent implements OnInit {
       this.loadInitialViewModel();
     }
 
-    this.focus$.pipe()
+    this.focusSubscription = this.focus$
       .pipe(withLatestFrom(this.change$))
       .subscribe(data => {
         const dataAtFocus = !!data[1] && !!data[1].data ? JSON.parse(JSON.stringify(data[1].data)) : null
@@ -181,13 +184,18 @@ export class FormViewModelComponent implements OnInit {
           })
       })
 
-    this.updateForm.pipe(filter(it => it), debounceTime(500)).subscribe(() => {
+    this.updateSubscription = this.updateForm.pipe(filter(it => it), debounceTime(500)).subscribe(() => {
       if (this.isStartForm$.value) {
         this.updateViewModelForStartForm();
       } else {
         this.updateViewModel();
       }
     })
+  }
+
+  public ngOnDestroy(): void {
+    this.focusSubscription.unsubscribe()
+    this.updateSubscription.unsubscribe()
   }
 
   public beforeSubmitHook(instance: FormViewModelComponent): (submission, callback) => void {

--- a/projects/valtimo/form-view-model/src/lib/components/form-view-model/form-view-model.component.ts
+++ b/projects/valtimo/form-view-model/src/lib/components/form-view-model/form-view-model.component.ts
@@ -169,7 +169,7 @@ export class FormViewModelComponent implements OnInit {
     this.focus$.pipe()
       .pipe(withLatestFrom(this.change$))
       .subscribe(data => {
-        let dataAtFocus = data[1] && data[1].data ? JSON.parse(JSON.stringify(data[1].data)) : null
+        const dataAtFocus = !!data[1] && !!data[1].data ? JSON.parse(JSON.stringify(data[1].data)) : null
         this.blur$
           .pipe(take(1))
           .pipe(withLatestFrom(this.change$))

--- a/projects/valtimo/form-view-model/src/lib/components/form-view-model/form-view-model.component.ts
+++ b/projects/valtimo/form-view-model/src/lib/components/form-view-model/form-view-model.component.ts
@@ -174,7 +174,7 @@ export class FormViewModelComponent implements OnInit {
           .pipe(take(1))
           .pipe(withLatestFrom(this.change$))
           .subscribe(dataBlur => {
-            let dataEqual = isEqual(dataAtFocus, dataBlur[1]?.data)
+            const dataEqual = isEqual(dataAtFocus, dataBlur[1]?.data)
             if(!dataEqual) {
               this.updateForm.next(true)
             }

--- a/projects/valtimo/form-view-model/src/lib/components/form-view-model/form-view-model.component.ts
+++ b/projects/valtimo/form-view-model/src/lib/components/form-view-model/form-view-model.component.ts
@@ -20,12 +20,12 @@ import {
   catchError,
   combineLatest,
   debounceTime,
-  EMPTY,
+  EMPTY, filter,
   Observable,
-  of,
+  of, Subject,
   switchMap,
   take,
-  tap,
+  tap, withLatestFrom,
 } from 'rxjs';
 import {
   FormioComponent,
@@ -41,6 +41,7 @@ import {FormIoStateService, ValtimoFormioOptions} from '@valtimo/components';
 import {TranslateService} from '@ngx-translate/core';
 import {HttpErrorResponse} from '@angular/common/http';
 import {CommonModule} from '@angular/common';
+import {isEqual} from 'lodash';
 
 moment.defaultFormat = 'DD MMM YYYY HH:mm';
 
@@ -108,11 +109,13 @@ export class FormViewModelComponent implements OnInit {
   public readonly taskInstanceId$ = new BehaviorSubject<string>(undefined);
   public readonly tokenSetInLocalStorage$ = new BehaviorSubject<boolean>(false);
   public readonly change$ = new BehaviorSubject<any>(null);
-  public readonly blur$ = new BehaviorSubject<FocusEvent>(null);
+  public readonly blur$ = new Subject<FocusEvent>();
+  public readonly focus$ = new BehaviorSubject<FocusEvent>(null);
   public readonly loading$ = new BehaviorSubject<boolean>(true);
   public readonly isStartForm$ = new BehaviorSubject<boolean>(false);
   public readonly processDefinitionKey$ = new BehaviorSubject<string>(undefined);
   public readonly documentDefinitionName$ = new BehaviorSubject<string>(undefined);
+  public readonly updateForm = new Subject<boolean>();
 
   public readonly currentLanguage$ = this.translateService.stream('key').pipe(
     map(() => this.translateService.currentLang),
@@ -162,6 +165,29 @@ export class FormViewModelComponent implements OnInit {
     } else {
       this.loadInitialViewModel();
     }
+
+    this.focus$.pipe()
+      .pipe(withLatestFrom(this.change$))
+      .subscribe(data => {
+        let dataAtFocus = data[1] && data[1].data ? JSON.parse(JSON.stringify(data[1].data)) : null
+        this.blur$
+          .pipe(take(1))
+          .pipe(withLatestFrom(this.change$))
+          .subscribe(dataBlur => {
+            let dataEqual = isEqual(dataAtFocus, dataBlur[1]?.data)
+            if(!dataEqual) {
+              this.updateForm.next(true)
+            }
+          })
+      })
+
+    this.updateForm.pipe(filter(it => it), debounceTime(500)).subscribe(() => {
+      if (this.isStartForm$.value) {
+        this.updateViewModelForStartForm();
+      } else {
+        this.updateViewModel();
+      }
+    })
   }
 
   public beforeSubmitHook(instance: FormViewModelComponent): (submission, callback) => void {
@@ -251,9 +277,12 @@ export class FormViewModelComponent implements OnInit {
     this.formSubmit.next(submission);
   }
 
+  public onFocus($event: FocusEvent): void {
+    this.focus$.next($event);
+  }
+
   public onBlur(blurEvent: FocusEvent): void {
     this.blur$.next(blurEvent);
-    this.handleChanges();
   }
 
   public onChange(object: any): void {
@@ -265,13 +294,13 @@ export class FormViewModelComponent implements OnInit {
   public onNextPage(): void {
     this._preventNextPage = true;
     this.formio.formio.setPage(this.formio.formio.page - 1);
-    this.handleChanges();
+    this.updateForm.next(true);
   }
 
   public onPreviousPage(): void {
     this._preventPreviousPage = true;
     this.formio.formio.setPage(this.formio.formio.page + 1);
-    this.handleChanges();
+    this.updateForm.next(true);
   }
 
   private handlePageChange(): void {
@@ -408,15 +437,5 @@ export class FormViewModelComponent implements OnInit {
         })
       )
       .subscribe();
-  }
-
-  private handleChanges(): void {
-    this.blur$.pipe(debounceTime(500)).subscribe(() => {
-      if (this.isStartForm$.value) {
-        this.updateViewModelForStartForm();
-      } else {
-        this.updateViewModel();
-      }
-    });
   }
 }


### PR DESCRIPTION
### Describe the changes

Bug exists where in FVM, when you open a dropdown box it fires an onBlur event, which refreshes the form.
This in turn hides the dropdown select box, making it impossible for the user to select a value.

This changes the logic to only update the form when the data was changed between component focus and blur

### Breaking changes

<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->

- [X] The contribution only contains changes that are not breaking.

### Documentation

<!-- Release notes should be available in the Valtimo documentation.  -->

- [X] Release notes have been written for these changes.

Link to the pull request in the
[Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):

> [PR
](https://github.com/valtimo-platform/valtimo-documentation/pull/761)

New features or changes that have been introduced have been documented.

- [X] Yes
- [ ] Not applicable
