### PR TITLE
Story/add document id to start form

### DIFF
--- a/projects/valtimo/dossier/src/lib/components/dossier-supporting-process-start-modal/dossier-supporting-process-start-modal.component.ts
+++ b/projects/valtimo/dossier/src/lib/components/dossier-supporting-process-start-modal/dossier-supporting-process-start-modal.component.ts
@@ -176,15 +176,17 @@ export class DossierSupportingProcessStartModalComponent {
       this.processDefinitionKey$,
       this.documentDefinitionName$,
       this.options$,
+      this.documentId$,
     ])
       .pipe(take(1))
-      .subscribe(([form, processDefinitionKey, documentDefinitionName, options]) => {
+      .subscribe(([form, processDefinitionKey, documentDefinitionName, options, documentId]) => {
         formViewModelComponent.instance.formName = formName;
         formViewModelComponent.instance.form = form;
         formViewModelComponent.instance.processDefinitionKey = processDefinitionKey;
         formViewModelComponent.instance.documentDefinitionName = documentDefinitionName;
         formViewModelComponent.instance.options = options;
         formViewModelComponent.instance.isStartForm = true;
+        formViewModelComponent.instance.documentId = documentId;
       });
 
     formViewModelComponent.instance.formSubmit.pipe(take(1)).subscribe(() => {

--- a/projects/valtimo/form-view-model/src/lib/components/form-view-model/form-view-model.component.ts
+++ b/projects/valtimo/form-view-model/src/lib/components/form-view-model/form-view-model.component.ts
@@ -214,6 +214,7 @@ export class FormViewModelComponent implements OnInit, OnDestroy {
       this.processDefinitionKey$,
       this.documentDefinitionName$,
       this.isStartForm$,
+      this.documentId$,
     ])
       .pipe(
         take(1),
@@ -224,12 +225,14 @@ export class FormViewModelComponent implements OnInit, OnDestroy {
             processDefinitionKey,
             documentDefinitionName,
             isStartForm,
+            documentId,
           ]) =>
             isStartForm
               ? this.viewModelService
                   .submitViewModelForStartForm(
                     formName,
                     processDefinitionKey,
+                    documentId,
                     documentDefinitionName,
                     submission.data
                   )
@@ -415,13 +418,14 @@ export class FormViewModelComponent implements OnInit, OnDestroy {
         switchMap(updating => {
           if (!updating) {
             this.loading$.next(true);
-            return combineLatest([this.formName$, this.processDefinitionKey$, this.change$]).pipe(
+            return combineLatest([this.formName$, this.processDefinitionKey$, this.change$, this.documentId$]).pipe(
               take(1),
-              switchMap(([formName, processDefinitionKey, change]) =>
+              switchMap(([formName, processDefinitionKey, change, documentId]) =>
                 this.viewModelService
                   .updateViewModelForStartForm(
                     formName,
                     processDefinitionKey,
+                    documentId,
                     change.data,
                     this.formio.formio.page,
                     this._isWizard

--- a/projects/valtimo/form-view-model/src/lib/components/form-view-model/form-view-model.component.ts
+++ b/projects/valtimo/form-view-model/src/lib/components/form-view-model/form-view-model.component.ts
@@ -85,6 +85,10 @@ export class FormViewModelComponent implements OnInit, OnDestroy {
     this.isStartForm$.next(isStartFormValue);
   }
 
+  @Input() set documentId(documentId: string) {
+    this.documentId$.next(documentId);
+  }
+
   @Input() set processDefinitionKey(processDefinitionKeyValue: string) {
     this.processDefinitionKey$.next(processDefinitionKeyValue);
   }
@@ -113,6 +117,7 @@ export class FormViewModelComponent implements OnInit, OnDestroy {
   public readonly focus$ = new BehaviorSubject<FocusEvent>(null);
   public readonly loading$ = new BehaviorSubject<boolean>(true);
   public readonly isStartForm$ = new BehaviorSubject<boolean>(false);
+  public readonly documentId$ = new BehaviorSubject<string>(null);
   public readonly processDefinitionKey$ = new BehaviorSubject<string>(undefined);
   public readonly documentDefinitionName$ = new BehaviorSubject<string>(undefined);
   public readonly updateForm = new Subject<boolean>();
@@ -385,11 +390,11 @@ export class FormViewModelComponent implements OnInit, OnDestroy {
   }
 
   public loadInitialViewModelForStartForm(): void {
-    combineLatest([this.formName$, this.processDefinitionKey$])
+    combineLatest([this.formName$, this.processDefinitionKey$, this.documentId$])
       .pipe(
         take(1),
-        switchMap(([formName, processDefinitionKey]) =>
-          this.viewModelService.getViewModelForStartForm(formName, processDefinitionKey).pipe(
+        switchMap(([formName, processDefinitionKey, documentId]) =>
+          this.viewModelService.getViewModelForStartForm(formName, processDefinitionKey, documentId).pipe(
             tap(viewModel => {
               this.submission$.next({data: viewModel});
               this.change$.pipe(take(1)).subscribe(() => {

--- a/projects/valtimo/form-view-model/src/lib/services/view-model.service.ts
+++ b/projects/valtimo/form-view-model/src/lib/services/view-model.service.ts
@@ -74,12 +74,14 @@ export class ViewModelService extends BaseApiService {
 
   public getViewModelForStartForm(
     formName: string,
-    processDefinitionKey: string
+    processDefinitionKey: string,
+    documentId: string = null,
   ): Observable<object> {
     return this.httpClient.get<any>(this.getApiUrl('/v1/form/view-model/start-form'), {
       params: {
         formName,
         processDefinitionKey,
+        documentId,
       },
       headers: new HttpHeaders().set(InterceptorSkip, '400'),
     });

--- a/projects/valtimo/form-view-model/src/lib/services/view-model.service.ts
+++ b/projects/valtimo/form-view-model/src/lib/services/view-model.service.ts
@@ -90,6 +90,7 @@ export class ViewModelService extends BaseApiService {
   public updateViewModelForStartForm(
     formName: string,
     processDefinitionKey: string,
+    documentId: string,
     viewModel: object,
     page: number,
     isWizard: boolean
@@ -97,6 +98,7 @@ export class ViewModelService extends BaseApiService {
     const params = {
       formName,
       processDefinitionKey,
+      documentId,
       isWizard,
       ...(!isNaN(page) && {page}),
     };
@@ -109,6 +111,7 @@ export class ViewModelService extends BaseApiService {
   public submitViewModelForStartForm(
     formName: string,
     processDefinitionKey: string,
+    documentId: string,
     documentDefinitionName: string,
     viewModel: object
   ): Observable<object> {
@@ -119,6 +122,7 @@ export class ViewModelService extends BaseApiService {
         params: {
           formName,
           processDefinitionKey,
+          documentId,
           documentDefinitionName,
         },
         headers: new HttpHeaders().set(InterceptorSkip, '400'),


### PR DESCRIPTION
### Describe the changes

When starting a form view model start-form for a supporting process, the documentId needs to be available, so that the submission of that start-form knows for which document to start processes

### Breaking changes

- [X] The contribution only contains changes that are not breaking.

### Documentation

<!-- Release notes should be available in the Valtimo documentation.  -->

- [ ] Release notes have been written for these changes.

Link to the pull request in the
[Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):

>

New features or changes that have been introduced have been documented.

- [ ] Yes
- [ ] Not applicable
