### PR TITLE
Add fix for width chaning in plugin config

### DIFF
--- a/projects/valtimo/components/src/lib/components/value-path-selector/value-path-selector.component.scss
+++ b/projects/valtimo/components/src/lib/components/value-path-selector/value-path-selector.component.scss
@@ -33,7 +33,9 @@
 }
 
 .value-path-selector__form {
-  display: flex;
+  display: grid;
+  grid-template-columns: 110px 1fr;
+
   width: 100%;
   align-items: center;
   gap: 16px;


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes

Link to the related Github issue:

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

**Relevant comments:**

> [[FE] The width of the selector changes after selecting a path](https://ritense.tpondemand.com/entity/131732-fe-the-width-of-the-selector)

### Breaking changes

<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->

- [x] The contribution only contains changes that are not breaking.

### Documentation

<!-- Release notes should be available in the Valtimo documentation.  -->

- [ ] Release notes have been written for these changes.

Link to the pull request in the
[Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):

>

New features or changes that have been introduced have been documented.

- [ ] Yes
- [ ] Not applicable
