### PR TITLE
fix: documenten api files duplicated on upload

### DIFF
--- a/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-metadata-modal/documenten-api-metadata-modal.component.ts
+++ b/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-metadata-modal/documenten-api-metadata-modal.component.ts
@@ -415,6 +415,7 @@ export class DocumentenApiMetadataModalComponent implements OnInit, OnDestroy {
 
   private _subscriptions = new Subscription();
   private _fileSubscription!: Subscription;
+  private _fileNameAndAuthorSubscription!: Subscription;
 
   constructor(
     private readonly route: ActivatedRoute,
@@ -437,6 +438,7 @@ export class DocumentenApiMetadataModalComponent implements OnInit, OnDestroy {
   public ngOnDestroy(): void {
     this._subscriptions.unsubscribe();
     this._fileSubscription?.unsubscribe();
+    this._fileNameAndAuthorSubscription?.unsubscribe();
     this.isDefinitiveStatus$.next(false);
   }
 
@@ -478,6 +480,7 @@ export class DocumentenApiMetadataModalComponent implements OnInit, OnDestroy {
 
   public prefillForm(file) {
     this.prefillFilenameAndAuthor();
+
     if (file) {
       const {
         beschrijving,
@@ -541,31 +544,30 @@ export class DocumentenApiMetadataModalComponent implements OnInit, OnDestroy {
   }
 
   private prefillFilenameAndAuthor() {
-    this._subscriptions.add(
-      combineLatest([this.file$, this.userEmail$])
-        .pipe(
-          tap(([file, userEmail]) => {
-            const filename = file?.bestandsnaam || this.defaultValues.bestandsnaam || file?.name;
-            this.filenameExtension = filename?.split('.')?.pop() || '';
-            if (this.filenameExtension.length === filename?.length) {
-              this.filenameExtension = '';
-            }
-            this.documentenApiMetadataForm.patchValue({
-              bestandsnaam: filename,
-              auteur: file?.auteur || this.defaultValues.auteur || userEmail,
-              creatiedatum: file?.creatiedatum || new Date(Date.now()),
-              titel:
-                file?.titel ||
-                this.defaultValues.titel ||
-                this.filenameToTitle(file?.name || this.defaultValues.bestandsnaam),
-            });
-            if (this.areAllFieldsHidden()) {
-              this.save();
-            }
-          })
-        )
-        .subscribe()
-    );
+    this._fileNameAndAuthorSubscription?.unsubscribe();
+    this._fileNameAndAuthorSubscription = combineLatest([this.file$, this.userEmail$])
+      .pipe(
+        tap(([file, userEmail]) => {
+          const filename = file?.bestandsnaam || this.defaultValues.bestandsnaam || file?.name;
+          this.filenameExtension = filename?.split('.')?.pop() || '';
+          if (this.filenameExtension.length === filename?.length) {
+            this.filenameExtension = '';
+          }
+          this.documentenApiMetadataForm.patchValue({
+            bestandsnaam: filename,
+            auteur: file?.auteur || this.defaultValues.auteur || userEmail,
+            creatiedatum: file?.creatiedatum || new Date(Date.now()),
+            titel:
+              file?.titel ||
+              this.defaultValues.titel ||
+              this.filenameToTitle(file?.name || this.defaultValues.bestandsnaam),
+          });
+          if (this.areAllFieldsHidden()) {
+            this.save();
+          }
+        })
+      )
+      .subscribe();
   }
 
   private filenameToTitle(filename?: string) {


### PR DESCRIPTION
closes https://ritense.tpondemand.com/entity/131284-fe-uploaded-files-duplicated