### PR TITLE
Fix sending value of documentId as a 'null' string on FVM handling

### DIFF
--- a/projects/valtimo/form-view-model/src/lib/services/view-model.service.ts
+++ b/projects/valtimo/form-view-model/src/lib/services/view-model.service.ts
@@ -81,7 +81,7 @@ export class ViewModelService extends BaseApiService {
       params: {
         formName,
         processDefinitionKey,
-        documentId,
+        ...(documentId != null && {documentId}),
       },
       headers: new HttpHeaders().set(InterceptorSkip, '400'),
     });
@@ -98,9 +98,9 @@ export class ViewModelService extends BaseApiService {
     const params = {
       formName,
       processDefinitionKey,
-      documentId,
       isWizard,
       ...(!isNaN(page) && {page}),
+      ...(documentId != null && {documentId})
     };
     return this.httpClient.post(this.getApiUrl(`/v1/form/view-model/start-form`), viewModel, {
       params,
@@ -122,8 +122,8 @@ export class ViewModelService extends BaseApiService {
         params: {
           formName,
           processDefinitionKey,
-          documentId,
           documentDefinitionName,
+          ...(documentId != null && {documentId}),
         },
         headers: new HttpHeaders().set(InterceptorSkip, '400'),
       }

--- a/projects/valtimo/form-view-model/src/lib/services/view-model.service.ts
+++ b/projects/valtimo/form-view-model/src/lib/services/view-model.service.ts
@@ -81,7 +81,7 @@ export class ViewModelService extends BaseApiService {
       params: {
         formName,
         processDefinitionKey,
-        ...(documentId != null && {documentId}),
+        ...(!!documentId && {documentId}),
       },
       headers: new HttpHeaders().set(InterceptorSkip, '400'),
     });
@@ -100,7 +100,7 @@ export class ViewModelService extends BaseApiService {
       processDefinitionKey,
       isWizard,
       ...(!isNaN(page) && {page}),
-      ...(documentId != null && {documentId})
+      ...(!!documentId && {documentId}),
     };
     return this.httpClient.post(this.getApiUrl(`/v1/form/view-model/start-form`), viewModel, {
       params,
@@ -123,7 +123,7 @@ export class ViewModelService extends BaseApiService {
           formName,
           processDefinitionKey,
           documentDefinitionName,
-          ...(documentId != null && {documentId}),
+          ...(!!documentId && {documentId}),
         },
         headers: new HttpHeaders().set(InterceptorSkip, '400'),
       }


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes

The value of documentId was sent as a 'null' string when starting,updating or submitting an FVM form. This cannot be parsed to a UUID by the API and threw an error

Link to the related Github issue:

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

**Relevant comments:**

>

### Breaking changes

<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->

- [x] The contribution only contains changes that are not breaking.

### Documentation

<!-- Release notes should be available in the Valtimo documentation.  -->

- [ ] Release notes have been written for these changes.

Link to the pull request in the
[Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):

>

New features or changes that have been introduced have been documented.

- [ ] Yes
- [ ] Not applicable
