### PR TITLE
176 Fixed bug where if the component has a default value, then the cu…

### DIFF
--- a/projects/valtimo/components/src/lib/components/form-io/form-io-currency/currency.component.ts
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io-currency/currency.component.ts
@@ -41,7 +41,7 @@ export class FormIoCurrencyComponent
   @Input() public set value(value: number) {
     this._value = value;
     this.currencyForm.setValue({
-      currencyValue: Currency.masking(value, this._currencyInstance.opts.maskOpts),
+      currencyValue: Currency.masking(value, this.maskOpts),
     });
   }
 
@@ -62,6 +62,18 @@ export class FormIoCurrencyComponent
   private _currencyInstance!: Currency;
 
   private readonly _subscriptions = new Subscription();
+
+  private get maskOpts(): any {
+    return {
+      empty: this.allowEmptyValue || false,
+      locales: this.currencyLocale || 'nl-NL',
+      digits: 2,
+      options: {
+        style: 'currency',
+        currency: this.currencyCurrency || 'EUR',
+      },
+    };
+  }
 
   public ngOnInit(): void {
     this._subscriptions.add(
@@ -85,15 +97,7 @@ export class FormIoCurrencyComponent
 
   public ngAfterViewInit(): void {
     this._currencyInstance = new Currency(this.currencyElement.nativeElement, {
-      maskOpts: {
-        empty: this.allowEmptyValue || false,
-        locales: this.currencyLocale || 'nl-NL',
-        digits: 2,
-        options: {
-          style: 'currency',
-          currency: this.currencyCurrency || 'EUR',
-        },
-      },
+      maskOpts: this.maskOpts,
     });
   }
 


### PR DESCRIPTION
…rrency is displayed incorrectly.

<!-- Please consider the following points before creating a pull request. -->

### Describe the changes

If the currency component has a default value, for example 100, then it is displayed €100,00 insted of €1,00.

Link to the related Github issue:

https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/176

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

**Relevant comments:**

>

### Breaking changes

<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->

- [ ] The contribution only contains changes that are not breaking.

### Documentation

<!-- Release notes should be available in the Valtimo documentation.  -->

- [ ] Release notes have been written for these changes.

Link to the pull request in the
[Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):

>

New features or changes that have been introduced have been documented.

- [ ] Yes
- [ ] Not applicable
