### PR TITLE
179 By default a field should not be required.

### DIFF
--- a/projects/valtimo/components/src/lib/components/form-io/form-io-currency/currency.formio.ts
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io-currency/currency.formio.ts
@@ -15,7 +15,7 @@ const COMPONENT_OPTIONS: FormioCustomComponentInfo = {
     hideLabel: false,
     tableView: true,
     validate: {
-      required: true,
+      required: false,
     },
   },
   editForm: currencyEditForm,

--- a/projects/valtimo/components/src/lib/components/form-io/form-io-iban/iban.formio.ts
+++ b/projects/valtimo/components/src/lib/components/form-io/form-io-iban/iban.formio.ts
@@ -14,7 +14,7 @@ const COMPONENT_OPTIONS: FormioCustomComponentInfo = {
     hideLabel: false,
     tableView: true,
     validate: {
-      required: true,
+      required: false,
     },
   },
 };


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
The default configuration of the currency and iban component makes it a required field.
This change changes the default configuration to make it a non required field.

Link to the related Github issue:
https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/179

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

**Relevant comments:**

>

### Breaking changes

<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->

- [ ] The contribution only contains changes that are not breaking.

### Documentation

<!-- Release notes should be available in the Valtimo documentation.  -->

- [ ] Release notes have been written for these changes.

Link to the pull request in the
[Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):

>

New features or changes that have been introduced have been documented.

- [ ] Yes
- [ ] Not applicable
