### PR TITLE
story/submission-button-on-fvm-error-keeps-spinning submission keeps …

### DIFF
--- a/projects/valtimo/form-view-model/src/lib/components/form-view-model/form-view-model.component.ts
+++ b/projects/valtimo/form-view-model/src/lib/components/form-view-model/form-view-model.component.ts
@@ -292,27 +292,36 @@ export class FormViewModelComponent implements OnInit, OnDestroy {
   }
 
   private handleFormError(error: HttpErrorResponse): void {
-    const formInstance = this.formio.formio;
+    const formio = this.formio.formio;
+    const formErrors = [];
+
     this.formErrors$.next([]);
-    if (error.error?.componentErrors) {
-      const errors = [];
-      error.error.componentErrors.forEach(componentError => {
-        const component = formInstance.getComponent(componentError.component);
-        if (component == null) {
-          errors.push(componentError.message);
+
+    const componentErrors = error?.error?.componentErrors;
+    const genericMessage = error?.error?.error;
+    const componentKey = error?.error?.component;
+
+    // Handle field-level (component) errors
+    if (Array.isArray(componentErrors)) {
+      for (const {component, message} of componentErrors) {
+        const field = formio.getComponent(component);
+        if (field) {
+          field.setCustomValidity(message, true); // Mark dirty
         } else {
-          // `true` makes the error dirty, setting the css class properly
-          component.setCustomValidity(componentError.message, true);
+          formErrors.push(message);
         }
-      });
-      this.formErrors$.next(errors);
-    } else if (error.error?.error) {
-      const component = formInstance.getComponent(error.error?.component);
-      if (component == null) {
-        this.formErrors$.next([error.error.error]);
+      }
+      this.formErrors$.next(formErrors);
+      return;
+    }
+
+    // Handle single (generic or component-specific) error
+    if (genericMessage) {
+      const field = formio.getComponent(componentKey);
+      if (field) {
+        field.setCustomValidity(genericMessage, true);
       } else {
-        // `true` makes the error dirty, setting the css class properly
-        component.setCustomValidity(error.error.error, true);
+        this.formErrors$.next([genericMessage]);
       }
     }
   }

--- a/projects/valtimo/form-view-model/src/lib/components/form-view-model/form-view-model.component.ts
+++ b/projects/valtimo/form-view-model/src/lib/components/form-view-model/form-view-model.component.ts
@@ -16,15 +16,15 @@
 import {Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild} from '@angular/core';
 import moment from 'moment';
 import {
-  BehaviorSubject,
-  combineLatest,
-  filter,
-  Observable,
-  Subject,
-  Subscription,
-  switchMap,
-  take,
-  tap,
+    BehaviorSubject,
+    combineLatest,
+    filter, interval, merge,
+    Observable,
+    Subject,
+    Subscription,
+    switchMap,
+    take,
+    tap,
 } from 'rxjs';
 import {
   FormioComponent,
@@ -115,7 +115,8 @@ export class FormViewModelComponent implements OnInit, OnDestroy {
   public readonly options$ = new BehaviorSubject<ValtimoFormioOptions>(undefined);
   public readonly taskInstanceId$ = new BehaviorSubject<string>(undefined);
   public readonly tokenSetInLocalStorage$ = new BehaviorSubject<boolean>(false);
-  public readonly change$ = new BehaviorSubject<any>(null);
+  public readonly data$ = new BehaviorSubject<any>(null);
+  public readonly changeEvents$ = new Subject<any>();
   public readonly blur$ = new Subject<FocusEvent>();
   public readonly focus$ = new BehaviorSubject<FocusEvent>(null);
   public readonly loading$ = new BehaviorSubject<boolean>(true);
@@ -227,55 +228,68 @@ export class FormViewModelComponent implements OnInit, OnDestroy {
   }
 
   public beforeSubmit(submission: any, callback: FormioSubmissionCallback): void {
-    this.pendingUpdateSubscription?.unsubscribe();
-    this.setWaitCursor(false);
+    this.changeEvents$.pipe(take(1)).subscribe({
+      next: ()=> {
+        this.pendingUpdateSubscription?.unsubscribe();
+        this.setWaitCursor(false);
 
-    combineLatest([
-      this.formName$,
-      this.taskInstanceId$,
-      this.processDefinitionKey$,
-      this.documentDefinitionName$,
-      this.isStartForm$,
-      this.documentId$,
-    ])
-      .pipe(
-        take(1),
-        switchMap(
-          ([
-            formName,
-            taskInstanceId,
-            processDefinitionKey,
-            documentDefinitionName,
-            isStartForm,
-            documentId,
-          ]) =>
-            isStartForm
-              ? this.viewModelService.submitViewModelForStartForm(
-                  formName,
-                  processDefinitionKey,
-                  documentId,
-                  documentDefinitionName,
-                  submission.data
+        combineLatest([
+          this.formName$,
+          this.taskInstanceId$,
+          this.processDefinitionKey$,
+          this.documentDefinitionName$,
+          this.isStartForm$,
+          this.documentId$,
+        ])
+            .pipe(
+                take(1),
+                tap(_ => console.log("before submit")),
+                switchMap(
+                    ([
+                       formName,
+                       taskInstanceId,
+                       processDefinitionKey,
+                       documentDefinitionName,
+                       isStartForm,
+                       documentId,
+                     ]) =>
+                        isStartForm
+                            ? this.viewModelService.submitViewModelForStartForm(
+                                formName,
+                                processDefinitionKey,
+                                documentId,
+                                documentDefinitionName,
+                                submission.data
+                            )
+                            : this.viewModelService.submitViewModel(formName, taskInstanceId, submission.data)
                 )
-              : this.viewModelService.submitViewModel(formName, taskInstanceId, submission.data)
-        )
-      )
-      .subscribe({
-        next: _ => {
-          callback(null, submission);
-        },
-        error: err => {
-          this.handleSubmissionError(err, callback);
-        },
-      });
+            )
+            .subscribe({
+              next: _ => {
+                callback(null, submission);
+              },
+              error: err => {
+                this.handleSubmissionError(err, callback);
+              },
+            });
+        }
+    })
   }
 
   private handleSubmissionError(error: any, callback: FormioSubmissionCallback): void {
-    callback({message: '', component: null, silent: true}, null);
-
     if (error instanceof HttpErrorResponse) {
-      this.handleFormError(error);
+      merge(
+          this.changeEvents$,
+          interval(200)
+      ).pipe(take(1)).subscribe({
+        next: () => {
+          console.log("handle form error")
+          this.handleFormError(error)
+        }
+      })
     }
+
+    callback({message: 'error', component: null, silent: false}, null);
   }
 
   private handleFormError(error: HttpErrorResponse): void {
@@ -317,8 +331,9 @@ export class FormViewModelComponent implements OnInit, OnDestroy {
   }
 
   public onChange(object: any): void {
+    this.changeEvents$.next(object);
     if (object.data) {
-      this.change$.next(object);
+      this.data$.next(object.data);
     }
   }
 
@@ -351,10 +366,10 @@ export class FormViewModelComponent implements OnInit, OnDestroy {
         switchMap(([formName, taskInstanceId]) =>
           this.viewModelService.getViewModel(formName, taskInstanceId).pipe(
             tap(viewModel => {
+                this.changeEvents$.pipe(take(1)).subscribe(() => {
+                    this.loading$.next(false);
+                });
               this.submission$.next({data: viewModel});
-              this.change$.pipe(take(1)).subscribe(() => {
-                this.loading$.next(false);
-              });
               this._isWizard = this.formio.form.display === 'wizard';
             })
           )
@@ -372,10 +387,10 @@ export class FormViewModelComponent implements OnInit, OnDestroy {
             .getViewModelForStartForm(formName, processDefinitionKey, documentId)
             .pipe(
               tap(viewModel => {
+                  this.changeEvents$.pipe(take(1)).subscribe(() => {
+                      this.loading$.next(false);
+                  });
                 this.submission$.next({data: viewModel});
-                this.change$.pipe(take(1)).subscribe(() => {
-                  this.loading$.next(false);
-                });
                 this._isWizard = this.formio.form.display === 'wizard';
               })
             )
@@ -390,16 +405,16 @@ export class FormViewModelComponent implements OnInit, OnDestroy {
     this.pendingUpdateSubscription = combineLatest([
       this.formName$,
       this.taskInstanceId$,
-      this.change$,
+      this.data$,
     ])
       .pipe(
         take(1),
-        switchMap(([formName, taskInstanceId, change]) =>
+        switchMap(([formName, taskInstanceId, data]) =>
           this.viewModelService
             .updateViewModel(
               formName,
               taskInstanceId,
-              change.data,
+              data,
               this.formio.formio.page,
               this._isWizard
             )
@@ -420,18 +435,18 @@ export class FormViewModelComponent implements OnInit, OnDestroy {
     this.pendingUpdateSubscription = combineLatest([
       this.formName$,
       this.processDefinitionKey$,
-      this.change$,
+      this.data$,
       this.documentId$,
     ])
       .pipe(
         take(1),
-        switchMap(([formName, processDefinitionKey, change, documentId]) =>
+        switchMap(([formName, processDefinitionKey, data, documentId]) =>
           this.viewModelService
             .updateViewModelForStartForm(
               formName,
               processDefinitionKey,
               documentId,
-              change.data,
+              data,
               this.formio.formio.page,
               this._isWizard
             )

--- a/projects/valtimo/form-view-model/src/lib/components/form-view-model/form-view-model.component.ts
+++ b/projects/valtimo/form-view-model/src/lib/components/form-view-model/form-view-model.component.ts
@@ -243,7 +243,6 @@ export class FormViewModelComponent implements OnInit, OnDestroy {
         ])
             .pipe(
                 take(1),
-                tap(_ => console.log("before submit")),
                 switchMap(
                     ([
                        formName,
@@ -283,7 +282,6 @@ export class FormViewModelComponent implements OnInit, OnDestroy {
           interval(200)
       ).pipe(take(1)).subscribe({
         next: () => {
-          console.log("handle form error")
           this.handleFormError(error)
         }
       })

--- a/projects/valtimo/form-view-model/src/lib/components/form-view-model/form-view-model.component.ts
+++ b/projects/valtimo/form-view-model/src/lib/components/form-view-model/form-view-model.component.ts
@@ -16,15 +16,17 @@
 import {Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild} from '@angular/core';
 import moment from 'moment';
 import {
-    BehaviorSubject,
-    combineLatest,
-    filter, interval, merge,
-    Observable,
-    Subject,
-    Subscription,
-    switchMap,
-    take,
-    tap,
+  BehaviorSubject,
+  combineLatest,
+  filter,
+  interval,
+  merge,
+  Observable,
+  Subject,
+  Subscription,
+  switchMap,
+  take,
+  tap,
 } from 'rxjs';
 import {
   FormioComponent,
@@ -229,7 +231,7 @@ export class FormViewModelComponent implements OnInit, OnDestroy {
 
   public beforeSubmit(submission: any, callback: FormioSubmissionCallback): void {
     this.changeEvents$.pipe(take(1)).subscribe({
-      next: ()=> {
+      next: () => {
         this.pendingUpdateSubscription?.unsubscribe();
         this.setWaitCursor(false);
 
@@ -241,50 +243,49 @@ export class FormViewModelComponent implements OnInit, OnDestroy {
           this.isStartForm$,
           this.documentId$,
         ])
-            .pipe(
-                take(1),
-                switchMap(
-                    ([
-                       formName,
-                       taskInstanceId,
-                       processDefinitionKey,
-                       documentDefinitionName,
-                       isStartForm,
-                       documentId,
-                     ]) =>
-                        isStartForm
-                            ? this.viewModelService.submitViewModelForStartForm(
-                                formName,
-                                processDefinitionKey,
-                                documentId,
-                                documentDefinitionName,
-                                submission.data
-                            )
-                            : this.viewModelService.submitViewModel(formName, taskInstanceId, submission.data)
-                )
+          .pipe(
+            take(1),
+            switchMap(
+              ([
+                formName,
+                taskInstanceId,
+                processDefinitionKey,
+                documentDefinitionName,
+                isStartForm,
+                documentId,
+              ]) =>
+                isStartForm
+                  ? this.viewModelService.submitViewModelForStartForm(
+                      formName,
+                      processDefinitionKey,
+                      documentId,
+                      documentDefinitionName,
+                      submission.data
+                    )
+                  : this.viewModelService.submitViewModel(formName, taskInstanceId, submission.data)
             )
-            .subscribe({
-              next: _ => {
-                callback(null, submission);
-              },
-              error: err => {
-                this.handleSubmissionError(err, callback);
-              },
-            });
-        }
-    })
+          )
+          .subscribe({
+            next: _ => {
+              callback(null, submission);
+            },
+            error: err => {
+              this.handleSubmissionError(err, callback);
+            },
+          });
+      },
+    });
   }
 
   private handleSubmissionError(error: any, callback: FormioSubmissionCallback): void {
     if (error instanceof HttpErrorResponse) {
-      merge(
-          this.changeEvents$,
-          interval(200)
-      ).pipe(take(1)).subscribe({
-        next: () => {
-          this.handleFormError(error)
-        }
-      })
+      merge(this.changeEvents$, interval(200))
+        .pipe(take(1))
+        .subscribe({
+          next: () => {
+            this.handleFormError(error);
+          },
+        });
     }
 
     callback({message: 'error', component: null, silent: false}, null);
@@ -364,9 +365,9 @@ export class FormViewModelComponent implements OnInit, OnDestroy {
         switchMap(([formName, taskInstanceId]) =>
           this.viewModelService.getViewModel(formName, taskInstanceId).pipe(
             tap(viewModel => {
-                this.changeEvents$.pipe(take(1)).subscribe(() => {
-                    this.loading$.next(false);
-                });
+              this.changeEvents$.pipe(take(1)).subscribe(() => {
+                this.loading$.next(false);
+              });
               this.submission$.next({data: viewModel});
               this._isWizard = this.formio.form.display === 'wizard';
             })
@@ -385,9 +386,9 @@ export class FormViewModelComponent implements OnInit, OnDestroy {
             .getViewModelForStartForm(formName, processDefinitionKey, documentId)
             .pipe(
               tap(viewModel => {
-                  this.changeEvents$.pipe(take(1)).subscribe(() => {
-                      this.loading$.next(false);
-                  });
+                this.changeEvents$.pipe(take(1)).subscribe(() => {
+                  this.loading$.next(false);
+                });
                 this.submission$.next({data: viewModel});
                 this._isWizard = this.formio.form.display === 'wizard';
               })


### PR DESCRIPTION
…spinning

### Describe the changes

Calling the callback from formIO on a beforeSubmit hook also triggers the onChange method, which clears any errors we want to display.

This change makes us wait for the change, before we set the errors

### Breaking changes

<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->

- [X] The contribution only contains changes that are not breaking.

### Documentation

<!-- Release notes should be available in the Valtimo documentation.  -->

- [ ] Release notes have been written for these changes.

Link to the pull request in the
[Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):

>

New features or changes that have been introduced have been documented.

- [ ] Yes
- [X] Not applicable
