### PR TITLE
fix: show error on no summary form

### DIFF
--- a/projects/valtimo/case/src/lib/case.module.ts
+++ b/projects/valtimo/case/src/lib/case.module.ts
@@ -68,6 +68,7 @@ import {
   LayerModule,
   LoadingModule,
   ModalModule as CarbonModalModule,
+  NotificationModule,
   SelectModule as CarbonSelectModule,
   SkeletonModule,
   TabsModule,
@@ -191,6 +192,7 @@ export type TabsFactory = () => Map<string, object>;
     ValtimoCdsModalDirective,
     TilesModule,
     LayerModule,
+    NotificationModule,
   ],
   exports: [CaseListComponent, CaseDetailComponent, CaseProcessStartModalComponent],
 })

--- a/projects/valtimo/case/src/lib/components/case-detail/tab/summary/summary.component.html
+++ b/projects/valtimo/case/src/lib/components/case-detail/tab/summary/summary.component.html
@@ -14,9 +14,12 @@
   ~ limitations under the License.
   -->
 
-<valtimo-form-io
-  *ngIf="formDefinition && document"
-  class="valtimo-summary-form"
-  [form]="formDefinition"
-  [options]="options"
-></valtimo-form-io>
+@if ((loading$ | async) && formDefinition && document) {
+  <valtimo-form-io
+    class="valtimo-summary-form"
+    [form]="formDefinition"
+    [options]="options"
+  ></valtimo-form-io>
+} @else if (notificationObj$ !== null) {
+  <cds-inline-notification [notificationObj]="notificationObj$ | async"></cds-inline-notification>
+}

--- a/projects/valtimo/case/src/lib/components/case-detail/tab/summary/summary.component.ts
+++ b/projects/valtimo/case/src/lib/components/case-detail/tab/summary/summary.component.ts
@@ -21,7 +21,10 @@ import {FormService} from '@valtimo/form';
 import {FormioOptionsImpl, ValtimoFormioOptions} from '@valtimo/components';
 import moment from 'moment';
 import {FormioForm} from '@formio/angular';
-import {Subscription} from 'rxjs';
+import {BehaviorSubject, combineLatest, map, Observable, of, Subscription, tap} from 'rxjs';
+import {NotificationContent} from 'carbon-components-angular';
+import {TranslateService} from '@ngx-translate/core';
+import {catchError} from 'rxjs/operators';
 
 moment.locale(localStorage.getItem('langKey') || '');
 moment.defaultFormat = 'DD MMM YYYY HH:mm';
@@ -40,13 +43,20 @@ export class CaseDetailTabSummaryComponent implements OnInit, OnDestroy {
   private snapshot: ParamMap;
   public moment!: typeof moment;
   public formDefinition: FormioForm = null;
+
+  public readonly loading$ = new BehaviorSubject<boolean>(true);
+
   public options: ValtimoFormioOptions;
+
+  public notificationObj$: Observable<NotificationContent> | null = null;
+
   private _subscriptions = new Subscription();
 
   constructor(
     private readonly documentService: DocumentService,
     private readonly route: ActivatedRoute,
-    private readonly formService: FormService
+    private readonly formService: FormService,
+    private readonly translateService: TranslateService
   ) {
     this.snapshot = this.route.snapshot.paramMap;
     this.caseDefinitionKey = this.snapshot.get('caseDefinitionKey') || '';
@@ -63,19 +73,41 @@ export class CaseDetailTabSummaryComponent implements OnInit, OnDestroy {
   public ngOnDestroy(): void {
     this._subscriptions.unsubscribe();
   }
+
   public init(): void {
     this._subscriptions.add(
-      this.documentService.getDocument(this.documentId).subscribe(document => {
-        this.document = document;
-      })
-    );
+      combineLatest([
+        this.documentService.getDocument(this.documentId).pipe(catchError(() => of(null))),
+        this.formService
+          .getFormDefinitionByNamePreFilled(`${this.caseDefinitionKey}.summary`, this.documentId)
+          .pipe(catchError(() => of(null))),
+      ])
+        .pipe(
+          tap(([document, formDefinition]) => {
+            this.document = document;
+            this.formDefinition = formDefinition;
 
-    this._subscriptions.add(
-      this.formService
-        .getFormDefinitionByNamePreFilled(`${this.caseDefinitionKey}.summary`, this.documentId)
-        .subscribe(formDefinition => {
-          this.formDefinition = formDefinition;
-        })
+            if (!formDefinition || !document) {
+              this.notificationObj$ = combineLatest([
+                this.translateService.stream('interface.warning'),
+                this.translateService.stream('case.summaryFormNotFound', {
+                  summary: this.caseDefinitionKey,
+                }),
+              ]).pipe(
+                map(([title, message]) => ({
+                  type: 'warning',
+                  title,
+                  message,
+                  showClose: false,
+                  lowContrast: true,
+                }))
+              );
+            }
+
+            this.loading$.next(false);
+          })
+        )
+        .subscribe()
     );
   }
 }

--- a/projects/valtimo/shared/assets/core/de.json
+++ b/projects/valtimo/shared/assets/core/de.json
@@ -15,6 +15,7 @@
     "TaskDueDateSetEvent": "Aufgabefrist gesetzt > {{taskName}}"
   },
   "case": {
+    "summaryFormNotFound": "Zusammenfassungsformular für '{{caseDefinitionKey}}' wurde nicht gefunden. Es muss ein Formular mit dem Namen '{{caseDefinitionKey}}.summary' existieren, das den Falldefinitionsschlüssel verwendet.",
     "bulkAssign": {
       "assign": "Zuweisen",
       "modal": {

--- a/projects/valtimo/shared/assets/core/en.json
+++ b/projects/valtimo/shared/assets/core/en.json
@@ -15,6 +15,7 @@
     "TaskDueDateSetEvent": "Task due date set > {{taskName}}"
   },
   "case": {
+    "summaryFormNotFound": "Summary form not found for '{{caseDefinitionKey}}'. A form named '{{caseDefinitionKey}}.summary' must exist using the case definition key.",
     "bulkAssign": {
       "assign": "Assign to",
       "modal": {

--- a/projects/valtimo/shared/assets/core/nl.json
+++ b/projects/valtimo/shared/assets/core/nl.json
@@ -15,6 +15,7 @@
     "TaskDueDateSetEvent": "Taak einddatum ingesteld > {{taskName}}"
   },
   "case": {
+    "summaryFormNotFound": "Samenvattingsformulier niet gevonden voor '{{caseDefinitionKey}}'. Er moet een formulier bestaan met de naam '{{caseDefinitionKey}}.summary' dat de dossierdefinitiesleutel gebruikt.",
     "bulkAssign": {
       "assign": "Toewijzen",
       "modal": {


### PR DESCRIPTION
closes https://ritense.tpondemand.com/entity/139294-be-not-existing-summary-tab-throws