### PR TITLE
Avoid page refresh after form duplication and add notification

### DIFF
--- a/projects/valtimo/form-management/src/lib/components/form-management-duplicate/form-management-duplicate.component.ts
+++ b/projects/valtimo/form-management/src/lib/components/form-management-duplicate/form-management-duplicate.component.ts
@@ -30,9 +30,9 @@ import {CreateFormDefinitionRequest, FormDefinition, FormManagementParams} from 
 import {FormManagementService} from '../../services';
 import {noDuplicateFormValidator} from '../../validators/no-duplicate-form.validator';
 import {CommonModule} from '@angular/common';
-import {TranslateModule} from '@ngx-translate/core';
+import {TranslateModule, TranslateService} from '@ngx-translate/core';
 import {ValtimoCdsModalDirective} from '@valtimo/components';
-import {ManagementContext} from '@valtimo/shared';
+import {GlobalNotificationService, ManagementContext} from '@valtimo/shared';
 
 @Component({
   selector: 'valtimo-form-management-duplicate-modal',
@@ -71,7 +71,9 @@ export class FormManagementDuplicateComponent extends BaseModal implements OnIni
     protected modalService: ModalService,
     protected formManagementService: FormManagementService,
     protected route: ActivatedRoute,
-    private router: Router
+    private router: Router,
+    private readonly notificationService: GlobalNotificationService,
+    private readonly translateService: TranslateService
   ) {
     super();
   }
@@ -93,7 +95,7 @@ export class FormManagementDuplicateComponent extends BaseModal implements OnIni
 
   public duplicate(): void {
     const control = this.duplicateFormName;
-
+    this.formToDuplicate.name = this.duplicateForm.controls['duplicateFormName'].value;
     const request: CreateFormDefinitionRequest = {
       name: control.value.toString(),
       formDefinition: JSON.stringify(this.formToDuplicate.formDefinition),
@@ -111,7 +113,13 @@ export class FormManagementDuplicateComponent extends BaseModal implements OnIni
       .subscribe({
         next: formDefinition => {
           this.disablePendingChangesCallback();
-          this.navigateWithNewId(formDefinition.id).then(() => window.location.reload());
+          this.navigateWithNewId(formDefinition.id).then(() => {
+            this.closeModal();
+            this.notificationService.showToast({
+              type: 'success',
+              title: this.translateService.instant('formManagement.notifications.duplicated'),
+            });
+          });
         },
         error: err => {
           if (err.toString().includes('Duplicate name')) {

--- a/projects/valtimo/shared/assets/core/de.json
+++ b/projects/valtimo/shared/assets/core/de.json
@@ -452,7 +452,8 @@
       "deleted": "Formular gelöscht",
       "deletionError": "Fehler beim Löschen des Formulars",
       "deployed": "Formular bereitgestellt",
-      "deploymentError": "Fehler beim Bereitstellen des Formulars"
+      "deploymentError": "Fehler beim Bereitstellen des Formulars",
+      "duplicated": "Formular dupliziert"
     },
     "upload": {
       "modalTitle": "Formulardefinition hochladen",

--- a/projects/valtimo/shared/assets/core/en.json
+++ b/projects/valtimo/shared/assets/core/en.json
@@ -447,7 +447,8 @@
       "deleted": "Deleted form",
       "deletionError": "Error deleting form",
       "deployed": "Form deployed",
-      "deploymentError": "Error deploying form"
+      "deploymentError": "Error deploying form",
+      "duplicated": "Form duplicated"
     },
     "upload": {
       "modalTitle": "Upload form definition",

--- a/projects/valtimo/shared/assets/core/nl.json
+++ b/projects/valtimo/shared/assets/core/nl.json
@@ -452,7 +452,8 @@
       "deleted": "Formulier verwijderd",
       "deletionError": "Fout bij het verwijderen van het formulier",
       "deployed": "Formulier gedeployed",
-      "deploymentError": "Fout bij het deployen van het formulier"
+      "deploymentError": "Fout bij het deployen van het formulier",
+      "duplicated": "Formulier gedupliceerd"
     },
     "upload": {
       "modalTitle": "Formulierdefinitie uploaden",


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Avoid page refresh after form duplication and show a confirmation message
Related to story: https://ritense.tpondemand.com/entity/139289-fe-frontent-refreshes-after-form-duplication

Link to the related Github issue:

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

**Relevant comments:**
- Navigate to the duplicated form instead of refreshing the page.
- Add notification for confirming the form was successfully duplicated.
>

### Breaking changes

<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->

- [x] The contribution only contains changes that are not breaking.

### Documentation

<!-- Release notes should be available in the Valtimo documentation.  -->

- [ ] Release notes have been written for these changes.

Link to the pull request in the
[Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):

>

New features or changes that have been introduced have been documented.

- [ ] Yes
- [x] Not applicable
