### PR TITLE
Hide duplicate form option when it is a final version

### DIFF
--- a/projects/valtimo/form-management/src/lib/components/form-management-edit/form-management-edit.component.html
+++ b/projects/valtimo/form-management/src/lib/components/form-management-edit/form-management-edit.component.html
@@ -132,7 +132,10 @@
           {{ 'Upload' | translate }}
         </cds-overflow-menu-option>
 
-        <cds-overflow-menu-option (selected)="showDuplicateModal(obs.formDefinition)">
+        <cds-overflow-menu-option
+          *ngIf="(obs.context === 'case' && obs.isDraftVersion) || obs.context === 'independent'"
+          (selected)="showDuplicateModal(obs.formDefinition)"
+        >
           {{ 'formManagement.duplicate' | translate }}
         </cds-overflow-menu-option>
 


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Hide duplicate form menu item when the version is a Final Version

Link to the related Github issue:

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

**Relevant comments:**
- Show duplicate form menu item when the version is a draft
- Show duplicate form menu item when it is Admin Forms
>

### Breaking changes

<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->

- [x] The contribution only contains changes that are not breaking.

### Documentation

<!-- Release notes should be available in the Valtimo documentation.  -->

- [ ] Release notes have been written for these changes.

Link to the pull request in the
[Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):

>

New features or changes that have been introduced have been documented.

- [ ] Yes
- [x] Not applicable
