### PR TITLE
Revert "132892 It is possible to select an orange tag. (#1418)"

### DIFF
--- a/projects/valtimo/components/assets/css/carbon.scss
+++ b/projects/valtimo/components/assets/css/carbon.scss
@@ -134,8 +134,3 @@ $darkThemeOverwriteVariables: (
   --vcds-color-20: #c9e9f9;
   --vcds-color-10: #e9f6fd;
 }
-
-.cds--tag--orange {
-  background-color: colors.$orange-40;
-  color: black;
-}

--- a/projects/valtimo/config/assets/core/de.json
+++ b/projects/valtimo/config/assets/core/de.json
@@ -1257,8 +1257,7 @@
       "cool-gray": "Kühles Grau",
       "warm-gray": "Warmes Grau",
       "high-contrast": "Hoher Kontrast",
-      "outline": "Umrissen",
-      "orange": "Orange"
+      "outline": "Umrissen"
     },
     "labels": {
       "dateCreationFrom": "Datum der Erstellung von",

--- a/projects/valtimo/config/assets/core/en.json
+++ b/projects/valtimo/config/assets/core/en.json
@@ -1262,8 +1262,7 @@
       "cool-gray": "Cool gray",
       "warm-gray": "Warm gray",
       "high-contrast": "High contrast",
-      "outline": "Outline",
-      "orange": "Orange"
+      "outline": "Outline"
     },
     "labels": {
       "dateCreationFrom": "Date creation from",

--- a/projects/valtimo/config/assets/core/nl.json
+++ b/projects/valtimo/config/assets/core/nl.json
@@ -1260,8 +1260,7 @@
       "cool-gray": "Koel grijs",
       "warm-gray": "Warm grijs",
       "high-contrast": "Hoog contrast",
-      "outline": "Omlijnd",
-      "orange": "Oranje"
+      "outline": "Omlijnd"
     },
     "labels": {
       "dateCreationFrom": "Aanmaakdatum van",

--- a/projects/valtimo/config/src/lib/models/tag-color.model.ts
+++ b/projects/valtimo/config/src/lib/models/tag-color.model.ts
@@ -11,5 +11,4 @@ export enum TagColor {
   CoolGray = 'COOLGRAY',
   HighContrast = 'HIGHCONTRAST',
   Outline = 'OUTLINE',
-  Orange = 'ORANGE',
 }


### PR DESCRIPTION
This reverts commit 1ec1b5a3197118fe4cec9858da6c5b425c1af868.

<!-- Please consider the following points before creating a pull request. -->

### Describe the changes

Link to the related Github issue:

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

**Relevant comments:**

>

### Breaking changes

<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->

- [ ] The contribution only contains changes that are not breaking.

### Documentation

<!-- Release notes should be available in the Valtimo documentation.  -->

- [ ] Release notes have been written for these changes.

Link to the pull request in the
[Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):

>

New features or changes that have been introduced have been documented.

- [ ] Yes
- [ ] Not applicable
