### PR TITLE
Fixes on FormManagement, ZGW, PluginManagement and CaseManagement

### DIFF
--- a/projects/valtimo/case-management/src/lib/components/case-management-detail/tabs/case-management-document-definition/case-management-document-definition.component.html
+++ b/projects/valtimo/case-management/src/lib/components/case-management-detail/tabs/case-management-document-definition/case-management-document-definition.component.html
@@ -26,27 +26,41 @@
     hasEditPermissions: hasEditPermissions$ | async,
   } as obs"
 >
-  <div *ngIf="!obs.editActive; else editActive" class="cds--toolbar-content">
-    <button
-      cdsButton="ghost"
-      [disabled]="obs.loadingDocumentDefinition || !obs.selectedDocumentDefinition"
-      (click)="downloadDefinition()"
-    >
-      {{ 'interface.download' | translate }}
+  <div class="cds--toolbar-content">
+    @if (!obs.editActive) {
+      <button
+        cdsButton="ghost"
+        [disabled]="obs.loadingDocumentDefinition || !obs.selectedDocumentDefinition"
+        (click)="downloadDefinition()"
+      >
+        {{ 'interface.download' | translate }}
 
-      <svg cdsIcon="download" size="16" class="cds--btn__icon"></svg>
-    </button>
+        <svg cdsIcon="download" size="16" class="cds--btn__icon"></svg>
+      </button>
 
-    <button
-      *ngIf="obs.hasEditPermissions"
-      cdsButton="primary"
-      [disabled]="obs.selectedDocumentDefinition?.readOnly"
-      (click)="onEditClick()"
-    >
-      {{ 'interface.edit' | translate }}
+      <button
+        *ngIf="obs.hasEditPermissions"
+        cdsButton="primary"
+        [disabled]="obs.selectedDocumentDefinition?.readOnly"
+        (click)="onEditClick()"
+      >
+        {{ 'interface.edit' | translate }}
 
-      <svg cdsIcon="edit" size="16" class="cds--btn__icon"></svg>
-    </button>
+        <svg cdsIcon="edit" size="16" class="cds--btn__icon"></svg>
+      </button>
+    } @else {
+      <button cdsButton="secondary" (click)="onCancelClick(obs.pendingChanges)">
+        {{ 'interface.cancel' | translate }}
+
+        <svg cdsIcon="close" size="16" class="cds--btn__icon"></svg>
+      </button>
+
+      <button cdsButton="primary" [disabled]="obs.saveButtonDisabled" (click)="onSaveClick()">
+        {{ 'interface.save' | translate }}
+
+        <svg cdsIcon="save" size="16" class="cds--btn__icon"></svg>
+      </button>
+    }
   </div>
 
   <valtimo-editor
@@ -61,20 +75,6 @@
   </valtimo-editor>
 
   <a id="downloadAnchorElement" style="display: none"></a>
-
-  <ng-template #editActive>
-    <button cdsButton="secondary" (click)="onCancelClick(obs.pendingChanges)">
-      {{ 'interface.cancel' | translate }}
-
-      <svg cdsIcon="close" size="16" class="cds--btn__icon"></svg>
-    </button>
-
-    <button cdsButton="primary" [disabled]="obs.saveButtonDisabled" (click)="onSaveClick()">
-      {{ 'interface.save' | translate }}
-
-      <svg cdsIcon="save" size="16" class="cds--btn__icon"></svg>
-    </button>
-  </ng-template>
 
   <valtimo-confirmation-modal
     [showModalSubject$]="showSaveConfirmation$"

--- a/projects/valtimo/form-management/src/lib/components/form-management-duplicate/form-management-duplicate.component.ts
+++ b/projects/valtimo/form-management/src/lib/components/form-management-duplicate/form-management-duplicate.component.ts
@@ -64,8 +64,9 @@ export class FormManagementDuplicateComponent extends BaseModal implements OnIni
 
   constructor(
     @Inject('formToDuplicate') public readonly formToDuplicate: FormDefinition,
-    @Inject('disabledPendingChangesCallback')
-    public readonly disablePendingChangesCallback: () => void,
+    // TODO: Figure out why this is breaking
+    // @Inject('disabledPendingChangesCallback')
+    // public readonly disablePendingChangesCallback: () => void,
     @Inject('context') public readonly context: ManagementContext,
     @Inject('params') public readonly params: FormManagementParams,
     protected modalService: ModalService,
@@ -112,7 +113,7 @@ export class FormManagementDuplicateComponent extends BaseModal implements OnIni
       .pipe(take(1))
       .subscribe({
         next: formDefinition => {
-          this.disablePendingChangesCallback();
+          // this.disablePendingChangesCallback();
           this.navigateWithNewId(formDefinition.id).then(() => {
             this.closeModal();
             this.notificationService.showToast({

--- a/projects/valtimo/form-management/src/lib/components/form-management-duplicate/form-management-duplicate.component.ts
+++ b/projects/valtimo/form-management/src/lib/components/form-management-duplicate/form-management-duplicate.component.ts
@@ -64,9 +64,6 @@ export class FormManagementDuplicateComponent extends BaseModal implements OnIni
 
   constructor(
     @Inject('formToDuplicate') public readonly formToDuplicate: FormDefinition,
-    // TODO: Figure out why this is breaking
-    // @Inject('disabledPendingChangesCallback')
-    // public readonly disablePendingChangesCallback: () => void,
     @Inject('context') public readonly context: ManagementContext,
     @Inject('params') public readonly params: FormManagementParams,
     protected modalService: ModalService,
@@ -113,7 +110,6 @@ export class FormManagementDuplicateComponent extends BaseModal implements OnIni
       .pipe(take(1))
       .subscribe({
         next: formDefinition => {
-          // this.disablePendingChangesCallback();
           this.navigateWithNewId(formDefinition.id).then(() => {
             this.closeModal();
             this.notificationService.showToast({

--- a/projects/valtimo/plugin-management/src/lib/components/plugin-management/plugin-management.component.ts
+++ b/projects/valtimo/plugin-management/src/lib/components/plugin-management/plugin-management.component.ts
@@ -37,6 +37,11 @@ import {v4 as uuidv4} from 'uuid';
 export class PluginManagementComponent {
   public readonly fields: ColumnConfig[] = [
     {
+      key: 'title',
+      label: 'pluginManagement.labels.configurationName',
+      viewType: ViewType.TEXT,
+    },
+    {
       key: 'pluginName',
       label: 'pluginManagement.labels.pluginName',
       viewType: ViewType.TEXT,
@@ -44,11 +49,6 @@ export class PluginManagementComponent {
     {
       key: 'definitionKey',
       label: 'pluginManagement.labels.identifier',
-      viewType: ViewType.TEXT,
-    },
-    {
-      key: 'title',
-      label: 'pluginManagement.labels.configurationName',
       viewType: ViewType.TEXT,
     },
   ];

--- a/projects/valtimo/zgw/src/lib/components/case-management-zgw/case-management-zgw.component.ts
+++ b/projects/valtimo/zgw/src/lib/components/case-management-zgw/case-management-zgw.component.ts
@@ -131,6 +131,7 @@ export class CaseManagementZgwComponent implements AfterViewInit, OnDestroy {
   public readonly DRAFT_WARNING_MESSAGE = {
     [ZgwTabEnum.DOCUMENTEN_API_COLUMNS]: 'zgw.tabs.documentColumns',
     [ZgwTabEnum.DOCUMENTEN_API_UPLOAD_FIELDS]: 'zgw.tabs.documentUploadFields',
+    [ZgwTabEnum.DOCUMENTEN_API_TAGS]: 'zgw.tabs.documentUploadFields',
   };
 
   constructor(


### PR DESCRIPTION
Fixes stories:
- [[FE] warning on zgw tab - rendering {{name}} instead of the name](https://ritense.tpondemand.com/entity/140469-fe-warning-on-zgw-tab-rendering)
- [[FE] document edit - Jumping ui](https://ritense.tpondemand.com/entity/140472-fe-document-edit-jumping-ui)
- [[FE] plugin tab labels](https://ritense.tpondemand.com/entity/140480-fe-plugin-tab-labels)

Placeholder fix for:  [[FE] form duplication - frontend crash](https://ritense.tpondemand.com/entity/140476-fe-form-duplication-frontend-crash)