### PR TITLE
Remove unnecessary condition

### DIFF
--- a/projects/valtimo/process-management/src/lib/components/process-management-builder/process-management-builder.component.html
+++ b/projects/valtimo/process-management/src/lib/components/process-management-builder/process-management-builder.component.html
@@ -145,7 +145,6 @@
         </button>
 
         <button
-          *ngIf="actionsObs.hasEditPermissions"
           [disabled]="!actionsObs.changesPending"
           cdsButton="primary"
           (click)="


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Should be possible to deploy process links, for that reason it is not necessary to hide the Save button for process management builder, otherwise it is not possible to deploy them

Link to the related Github issue:

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

**Relevant comments:**
Related to this story: https://ritense.tpondemand.com/entity/137720-fe-disable-admin-configuration
>

### Breaking changes

<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->

- [x] The contribution only contains changes that are not breaking.

### Documentation

<!-- Release notes should be available in the Valtimo documentation.  -->

- [ ] Release notes have been written for these changes.

Link to the pull request in the
[Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):

>

New features or changes that have been introduced have been documented.

- [ ] Yes
- [x] Not applicable
