### PR TITLE
Fix to enable the submit button correctly on a Form.io form inside a …

### DIFF
--- a/projects/valtimo/zgw/src/lib/modules/documenten-api/formio/documenten-api-uploader/documenten-api-uploader.component.ts
+++ b/projects/valtimo/zgw/src/lib/modules/documenten-api/formio/documenten-api-uploader/documenten-api-uploader.component.ts
@@ -187,18 +187,18 @@ export class DocumentenApiUploaderComponent
 
   @Output() valueChange = new EventEmitter<Array<DocumentenApiFileReference>>();
 
-  readonly uploading$ = new BehaviorSubject<boolean>(false);
-  readonly fileToBeUploaded$ = new BehaviorSubject<File | null>(null);
-  readonly modalDisabled$ = new BehaviorSubject<boolean>(false);
-  readonly showModal = signal<boolean>(false);
-  readonly uploadProcessLinked$: Observable<boolean | string> =
+  public readonly uploading$ = new BehaviorSubject<boolean>(false);
+  public readonly fileToBeUploaded$ = new BehaviorSubject<File | null>(null);
+  public readonly modalDisabled$ = new BehaviorSubject<boolean>(false);
+  public readonly showModal = signal<boolean>(false);
+  public readonly uploadProcessLinked$: Observable<boolean | string> =
     this.modalService.caseDefinitionKey$.pipe(
       switchMap(caseDefinitionKey =>
         this.uploadProviderService.checkUploadProcessLink(caseDefinitionKey)
       ),
       startWith('loading')
     );
-  readonly isAdmin$: Observable<boolean> = this.userProviderService
+  public readonly isAdmin$: Observable<boolean> = this.userProviderService
     .getUserSubject()
     .pipe(map(userIdentity => userIdentity?.roles.includes('ROLE_ADMIN')));
 
@@ -246,12 +246,12 @@ export class DocumentenApiUploaderComponent
     }
   }
 
-  fileSelected(file: File): void {
+  public fileSelected(file: File): void {
     this.fileToBeUploaded$.next(file);
     this.showModal.set(true);
   }
 
-  deleteFile(id: string): void {
+  public deleteFile(id: string): void {
     this.domService.toggleSubmitButton(true);
     this._value = this._value.filter((file: DocumentenApiFileReference) =>
       file?.id ? file?.id !== id : true
@@ -259,11 +259,11 @@ export class DocumentenApiUploaderComponent
     this.valueChange.emit(this._value);
   }
 
-  closeMetadataModal(): void {
+  public closeMetadataModal(): void {
     this.showModal.set(false);
   }
 
-  metadataSet(metadata: DocumentenApiMetadata): void {
+  public metadataSet(metadata: DocumentenApiMetadata): void {
     this.uploading$.next(true);
     this.showModal.set(false);
     this.domService.toggleSubmitButton(true);
@@ -275,7 +275,7 @@ export class DocumentenApiUploaderComponent
         tap(result => {
           this.domService.toggleSubmitButton(false);
           this.uploading$.next(false);
-          this._value.push(result);
+          this._value = [...this._value, result];
           this.valueChange.emit(this._value);
         })
       )


### PR DESCRIPTION
…user task

<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
When using the _documenten-api-file-uploader_, the submit button was not enabled correctly. This issue has been fixed in this pull request

Link to the related Github issue:  https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/212

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

**Relevant comments:**
Some minor corrections were also made
>

### Breaking changes

<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->

- [x] The contribution only contains changes that are not breaking.

### Documentation

<!-- Release notes should be available in the Valtimo documentation.  -->

- [ ] Release notes have been written for these changes.

Link to the pull request in the
[Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):

>

New features or changes that have been introduced have been documented.

- [ ] Yes
- [x] Not applicable
