### PR TITLE
User task subtitles: Show with task when configured, removed 'open' permission restriction

### DIFF
--- a/projects/valtimo/case/src/lib/components/case-detail-task-list/case-detail-task-list.component.html
+++ b/projects/valtimo/case/src/lib/components/case-detail-task-list/case-detail-task-list.component.html
@@ -95,7 +95,7 @@
 
       <div class="task__subtitles">
         @for (
-          subtitle of taskWithProcessLink?.processLinkActivityResult?.properties?.subtitles || [];
+          subtitle of taskWithProcessLink?.task?.subtitles || [];
           track subtitle
         ) {
           <p class="task__subtitle">{{ subtitle }}</p>

--- a/projects/valtimo/case/src/lib/components/case-detail-task-list/case-detail-task-list.component.html
+++ b/projects/valtimo/case/src/lib/components/case-detail-task-list/case-detail-task-list.component.html
@@ -95,7 +95,7 @@
 
       <div class="task__subtitles">
         @for (
-          subtitle of taskWithProcessLink?.task?.subtitles || [];
+          subtitle of taskWithProcessLink.task?.subtitles || [];
           track subtitle
         ) {
           <p class="task__subtitle">{{ subtitle }}</p>

--- a/projects/valtimo/case/src/lib/components/case-detail-task-list/case-detail-task-list.component.ts
+++ b/projects/valtimo/case/src/lib/components/case-detail-task-list/case-detail-task-list.component.ts
@@ -160,10 +160,10 @@ export class CaseDetailTaskListComponent {
     this.iconService.registerAll([UserFilled20]);
   }
 
-  public rowTaskClick(tasWithProcessLinkk: TaskWithProcessLink): void {
-    if (tasWithProcessLinkk.task.isLocked) return;
+  public rowTaskClick(tasWithProcessLink: TaskWithProcessLink): void {
+    if (tasWithProcessLink.task.isLocked) return;
 
-    this.taskClickEvent.emit(tasWithProcessLinkk);
+    this.taskClickEvent.emit(tasWithProcessLink);
   }
 
   public onFormSubmit(): void {

--- a/projects/valtimo/process/src/lib/models/process.model.ts
+++ b/projects/valtimo/process/src/lib/models/process.model.ts
@@ -123,6 +123,7 @@ interface ProcessInstanceTask {
   tenantId: string;
   identityLinks: IdentityLink[];
   isLocked: boolean;
+  subtitles?: string[];
 }
 
 interface IdentityLink {


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/58

Changed when subtitles configured for a User task are displayed. Now they are displayed when they are configured for a user task leaving out if the user has permission to 'open' the task.

**Relevant comments:**
> When this feature was added the display of the subtitles was limited to tasks the user has permission to 'open' while in the original feature request this was not specifically requested. The expectation was that when subtitles are configured these are displayed at the user task nevertheless. This PR changes that behavior.

### Breaking changes

<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->

- [x] The contribution only contains changes that are not breaking.

### Documentation

<!-- Release notes should be available in the Valtimo documentation.  -->

- [ ] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.

- [ ] Yes
- [x] Not applicable
