### PR TITLE
Added Github actions workflow to check for the 'tested' label on a PR.

### DIFF
--- a/.github/workflows/check-tested-label.yml
+++ b/.github/workflows/check-tested-label.yml
@@ -1,0 +1,28 @@
+name: Check for "tested" label
+permissions:
+    contents: read
+
+on:
+    pull_request:
+        types: [labeled, unlabeled, opened, synchronize, reopened]
+
+jobs:
+    label-check:
+        name: PR must have "tested" label
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Check for label
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const labels = await github.rest.issues.listLabelsOnIssue({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: context.issue.number
+                      });
+
+                      const hasTested = labels.data.some(label => label.name === 'tested');
+                      if (!hasTested) {
+                        core.setFailed('Missing required "tested" label on the PR.');
+                      }


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes

Link to the related Github issue:

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

**Relevant comments:**

>

### Breaking changes

<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->

- [x] The contribution only contains changes that are not breaking.

### Documentation

<!-- Release notes should be available in the Valtimo documentation.  -->

- [ ] Release notes have been written for these changes.

Link to the pull request in the
[Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):

>

New features or changes that have been introduced have been documented.

- [ ] Yes
- [x] Not applicable
